### PR TITLE
Add optimized TMC Continuous Director v5

### DIFF
--- a/TMC_ContinuousDirector_v5/README.txt
+++ b/TMC_ContinuousDirector_v5/README.txt
@@ -33,6 +33,7 @@ private _settings = createHashMapFromArray [
     ["stuckTimeout",75],
     ["infantryMinimumServerFPS",18],
     ["vehicleMinimumServerFPS",18],
+    ["estimatedInfantryPerGroup",29],
     ["debugMode","NONE"]
 ];
 ["START",thisTrigger,_settings] execVM "TMC_ContinuousDirector.sqf";
@@ -46,11 +47,18 @@ Server Only: Yes
 Behavior:
 Three managed OPFOR infantry per living BLUFOR in the scaling area.
 One managed OPFOR vehicle per ten living BLUFOR, minimum one while BLUFOR are present.
+The director calculates reinforcement requirements from the actual number of living managed OPFOR infantry, not from the number of OPFOR groups.
 One infantry group may be requested every five seconds.
 One vehicle may be requested every ten seconds, offset by 2.5 seconds.
-B1 and B2 groups contain sixteen units.
-Droidekas spawn as independent one-unit groups.
-BX commandos use a separate six-unit team.
+The primary infantry pool uses large groups of forty, thirty, and twenty droids to reduce the number of AI group leaders.
+The forty-unit group is a B1 assault formation.
+The thirty-unit group is a B1 fire-support formation.
+The twenty-unit group is a mixed B1/B2 assault formation.
+Large formations have a combined weight of twenty-eight while each specialty formation has a weight of one, so normal director packages strongly favor the larger groups.
+BX commandos use a separate six-unit team: one captain, three standard BX droids, and two assassins.
+B2 Hunter Cells spawn as independent three-unit B2 groups.
+Droidekas spawn as independent one-unit groups so they retain their own movement behavior.
+The recommended pending-package estimate is twenty-nine infantry per group, matching the weighted template average.
 Each infantry group receives a LAMBS Task CQB waypoint centered on the nearest living ground-based BLUFOR group leader.
 The waypoint updates when its target changes or moves at least thirty-five meters.
 Infantry ignores aircraft through a cached aircraft registry and an EntityCreated event handler.

--- a/TMC_ContinuousDirector_v5/README.txt
+++ b/TMC_ContinuousDirector_v5/README.txt
@@ -28,6 +28,8 @@ private _settings = createHashMapFromArray [
     ["infantryEvaluationInterval",5],
     ["vehicleEvaluationInterval",10],
     ["vehicleEvaluationOffset",2.5],
+    ["behaviorEvaluationInterval",20],
+    ["stuckTimeout",75],
     ["infantryMinimumServerFPS",18],
     ["vehicleMinimumServerFPS",18],
     ["debugMode","LOG"]
@@ -40,21 +42,23 @@ Activation Type: Present
 Repeatable: No
 Server Only: Yes
 
-The trigger or marker passed to START is the LAMBS taskAssault destination. Name the marker defense_center when calling the wrapper directly.
-
 Behavior:
 Three managed OPFOR infantry per living BLUFOR in the scaling area.
 One managed OPFOR vehicle per ten living BLUFOR, minimum one while BLUFOR are present.
 One infantry group may be requested every five seconds.
 One vehicle may be requested every ten seconds, offset by 2.5 seconds.
 B1 and B2 groups contain sixteen units.
-Droidekas use separate two- or three-unit groups.
+Droidekas spawn as independent one-unit groups so each can roll and maneuver separately.
 BX commandos use a separate six-unit team.
+Each infantry group receives a LAMBS Task CQB waypoint centered on the nearest living BLUFOR group leader.
+The director updates that waypoint when the selected BLUFOR leader moves.
+Infantry ignores aircraft, uses AWARE and YELLOW behavior, keeps enableAttack disabled, and retains FULL speed.
+A behavior watchdog checks groups every twenty seconds and reissues movement after seventy-five seconds without meaningful progress.
 LAMBS reinforcement and radio sharing are enabled.
 Knowledge seeding chance is 25 percent.
 Visibility tests only consider players within 1500 meters of the candidate spawn.
 Position searches use forty attempts.
-All spawned infantry have stamina and fatigue disabled and use FULL group speed.
+All spawned infantry have stamina and fatigue disabled.
 
 Commands:
 ["STATUS"] execVM "TMC_ContinuousDirector.sqf";

--- a/TMC_ContinuousDirector_v5/README.txt
+++ b/TMC_ContinuousDirector_v5/README.txt
@@ -68,6 +68,7 @@ The destination group must have enough capacity to remain at or below thirty liv
 The director prefers an established destination group with at least five living units before considering another depleted group.
 Groups do not merge while the source or destination is actively clearing buildings, rushing an enemy, or fighting an enemy within 125 meters.
 Survivors transfer with joinSilent and follow the surviving destination leader.
+The destination group's movement-progress tracking is reset after a merge so a leader change is not falsely treated as a stuck group.
 Merging does not change the director infantry count and therefore does not create a false reinforcement deficit.
 The weighted pending-package estimate is twenty infantry per group.
 Each infantry group receives a LAMBS Task CQB waypoint centered on the nearest living ground-based BLUFOR group leader.

--- a/TMC_ContinuousDirector_v5/README.txt
+++ b/TMC_ContinuousDirector_v5/README.txt
@@ -1,0 +1,63 @@
+TMC Continuous Director v5
+
+Files:
+TMC_ContinuousDirector.sqf
+TMC_AttackWave_CloneWars.sqf
+TMC_fnc_spawnAttackWave.sqf
+TMC_CfgFunctions.hpp
+
+Place the three SQF files in the mission root.
+
+Either include TMC_CfgFunctions.hpp inside description.ext:
+
+class CfgFunctions
+{
+    #include "TMC_CfgFunctions.hpp"
+};
+
+Or allow TMC_AttackWave_CloneWars.sqf to compile the function automatically.
+
+Recommended trigger On Activation:
+
+private _settings = createHashMapFromArray [
+    ["scalingMode","AREA"],
+    ["scalingSide",west],
+    ["initialDelay",1],
+    ["enemyRatio",3],
+    ["scalingUnitsPerVehicle",10],
+    ["infantryEvaluationInterval",5],
+    ["vehicleEvaluationInterval",10],
+    ["vehicleEvaluationOffset",2.5],
+    ["infantryMinimumServerFPS",18],
+    ["vehicleMinimumServerFPS",18],
+    ["debugMode","LOG"]
+];
+["START",thisTrigger,_settings] execVM "TMC_ContinuousDirector.sqf";
+
+Trigger settings:
+Activation: Any Player
+Activation Type: Present
+Repeatable: No
+Server Only: Yes
+
+The trigger or marker passed to START is the LAMBS taskAssault destination. Name the marker defense_center when calling the wrapper directly.
+
+Behavior:
+Three managed OPFOR infantry per living BLUFOR in the scaling area.
+One managed OPFOR vehicle per ten living BLUFOR, minimum one while BLUFOR are present.
+One infantry group may be requested every five seconds.
+One vehicle may be requested every ten seconds, offset by 2.5 seconds.
+B1 and B2 groups contain sixteen units.
+Droidekas use separate two- or three-unit groups.
+BX commandos use a separate six-unit team.
+LAMBS reinforcement and radio sharing are enabled.
+Knowledge seeding chance is 25 percent.
+Visibility tests only consider players within 1500 meters of the candidate spawn.
+Position searches use forty attempts.
+All spawned infantry have stamina and fatigue disabled and use FULL group speed.
+
+Commands:
+["STATUS"] execVM "TMC_ContinuousDirector.sqf";
+["PAUSE"] execVM "TMC_ContinuousDirector.sqf";
+["RESUME"] execVM "TMC_ContinuousDirector.sqf";
+["STOP"] execVM "TMC_ContinuousDirector.sqf";

--- a/TMC_ContinuousDirector_v5/README.txt
+++ b/TMC_ContinuousDirector_v5/README.txt
@@ -23,6 +23,7 @@ private _settings = createHashMapFromArray [
     ["scalingMode","AREA"],
     ["scalingSide",west],
     ["initialDelay",1],
+    ["scalingEvaluationInterval",5],
     ["enemyRatio",3],
     ["scalingUnitsPerVehicle",10],
     ["infantryEvaluationInterval",5],
@@ -32,7 +33,7 @@ private _settings = createHashMapFromArray [
     ["stuckTimeout",75],
     ["infantryMinimumServerFPS",18],
     ["vehicleMinimumServerFPS",18],
-    ["debugMode","LOG"]
+    ["debugMode","NONE"]
 ];
 ["START",thisTrigger,_settings] execVM "TMC_ContinuousDirector.sqf";
 
@@ -48,17 +49,29 @@ One managed OPFOR vehicle per ten living BLUFOR, minimum one while BLUFOR are pr
 One infantry group may be requested every five seconds.
 One vehicle may be requested every ten seconds, offset by 2.5 seconds.
 B1 and B2 groups contain sixteen units.
-Droidekas spawn as independent one-unit groups so each can roll and maneuver separately.
+Droidekas spawn as independent one-unit groups.
 BX commandos use a separate six-unit team.
-Each infantry group receives a LAMBS Task CQB waypoint centered on the nearest living BLUFOR group leader.
-The director updates that waypoint when the selected BLUFOR leader moves.
-Infantry ignores aircraft, uses AWARE and YELLOW behavior, keeps enableAttack disabled, and retains FULL speed.
-A behavior watchdog checks groups every twenty seconds and reissues movement after seventy-five seconds without meaningful progress.
+Each infantry group receives a LAMBS Task CQB waypoint centered on the nearest living ground-based BLUFOR group leader.
+The waypoint updates when its target changes or moves at least thirty-five meters.
+Infantry ignores aircraft through a cached aircraft registry and an EntityCreated event handler.
+A behavior watchdog checks every twenty seconds.
+Groups are not treated as stuck while near enemies, actively clearing buildings, or within one hundred meters of their target.
 LAMBS reinforcement and radio sharing are enabled.
 Knowledge seeding chance is 25 percent.
-Visibility tests only consider players within 1500 meters of the candidate spawn.
+Visibility tests only consider players within 1500 meters of a candidate spawn.
 Position searches use forty attempts.
 All spawned infantry have stamina and fatigue disabled.
+
+Efficiency changes:
+The director uses managed group and vehicle registries instead of repeatedly scanning allGroups and vehicles.
+The main scheduler exits immediately unless a scaling, infantry, vehicle, behavior, or status evaluation is due.
+The allUnits scaling scan runs on its own five-second interval.
+Living players are cached once per spawn package and reused for distance, visibility, and target selection.
+Clone Wars templates and class validation are cached once per mission.
+The wrapper calls the spawn function directly without creating a second scheduled script.
+The spawn delay is zero for normal one-group director packages.
+Debug logging defaults to NONE and periodic status logging only runs when LOG or MARKERS mode is enabled.
+Aircraft ignore commands are only applied when a group or aircraft is newly registered.
 
 Commands:
 ["STATUS"] execVM "TMC_ContinuousDirector.sqf";

--- a/TMC_ContinuousDirector_v5/README.txt
+++ b/TMC_ContinuousDirector_v5/README.txt
@@ -31,9 +31,13 @@ private _settings = createHashMapFromArray [
     ["vehicleEvaluationOffset",2.5],
     ["behaviorEvaluationInterval",20],
     ["stuckTimeout",75],
+    ["mergeEnabled",true],
+    ["mergeThreshold",5],
+    ["mergeSearchRadius",300],
+    ["maximumMergedGroupSize",30],
     ["infantryMinimumServerFPS",18],
     ["vehicleMinimumServerFPS",18],
-    ["estimatedInfantryPerGroup",29],
+    ["estimatedInfantryPerGroup",20],
     ["debugMode","NONE"]
 ];
 ["START",thisTrigger,_settings] execVM "TMC_ContinuousDirector.sqf";
@@ -50,15 +54,22 @@ One managed OPFOR vehicle per ten living BLUFOR, minimum one while BLUFOR are pr
 The director calculates reinforcement requirements from the actual number of living managed OPFOR infantry, not from the number of OPFOR groups.
 One infantry group may be requested every five seconds.
 One vehicle may be requested every ten seconds, offset by 2.5 seconds.
-The primary infantry pool uses large groups of forty, thirty, and twenty droids to reduce the number of AI group leaders.
-The forty-unit group is a B1 assault formation.
-The thirty-unit group is a B1 fire-support formation.
-The twenty-unit group is a mixed B1/B2 assault formation.
-Large formations have a combined weight of twenty-eight while each specialty formation has a weight of one, so normal director packages strongly favor the larger groups.
+The regular infantry pool uses weighted formations of thirty, twenty, and ten droids.
+The thirty-unit group is a B1 assault formation.
+The twenty-unit group is a B1 fire-support formation.
+The ten-unit group is a mixed B1 and B2 assault formation.
 BX commandos use a separate six-unit team: one captain, three standard BX droids, and two assassins.
 B2 Hunter Cells spawn as independent three-unit B2 groups.
-Droidekas spawn as independent one-unit groups so they retain their own movement behavior.
-The recommended pending-package estimate is twenty-nine infantry per group, matching the weighted template average.
+Droidekas spawn as independent one-unit groups.
+Only the thirty, twenty, and ten-unit regular formations may merge.
+BX teams, B2 Hunter Cells, Droidekas, and vehicle crews never merge.
+During each twenty-second behavior evaluation, a mergeable group with one to four living units searches for another eligible regular infantry group within 300 meters.
+The destination group must have enough capacity to remain at or below thirty living units.
+The director prefers an established destination group with at least five living units before considering another depleted group.
+Groups do not merge while the source or destination is actively clearing buildings, rushing an enemy, or fighting an enemy within 125 meters.
+Survivors transfer with joinSilent and follow the surviving destination leader.
+Merging does not change the director infantry count and therefore does not create a false reinforcement deficit.
+The weighted pending-package estimate is twenty infantry per group.
 Each infantry group receives a LAMBS Task CQB waypoint centered on the nearest living ground-based BLUFOR group leader.
 The waypoint updates when its target changes or moves at least thirty-five meters.
 Infantry ignores aircraft through a cached aircraft registry and an EntityCreated event handler.
@@ -69,6 +80,15 @@ Knowledge seeding chance is 25 percent.
 Visibility tests only consider players within 1500 meters of a candidate spawn.
 Position searches use forty attempts.
 All spawned infantry have stamina and fatigue disabled.
+
+Pause behavior:
+The director does not automatically enter its paused state because of low server FPS, a missing infantry deficit, a lack of BLUFOR, or exhausted group slots.
+The paused state is entered only when the PAUSE command is executed.
+While paused, the scheduler performs no scaling checks, spawning, retasking, stuck recovery, merging, or status updates.
+Already-spawned AI continue using their existing Arma and LAMBS orders.
+Low server FPS only blocks new infantry or vehicle packages until FPS recovers above the configured minimum.
+An invalid center reference stops the director rather than pausing it.
+The STOP command removes the scheduler and aircraft event handler and terminates pending spawn scripts, but it does not delete already-spawned forces.
 
 Efficiency changes:
 The director uses managed group and vehicle registries instead of repeatedly scanning allGroups and vehicles.

--- a/TMC_ContinuousDirector_v5/TMC_AttackWave_CloneWars.sqf
+++ b/TMC_ContinuousDirector_v5/TMC_AttackWave_CloneWars.sqf
@@ -5,207 +5,282 @@ if (isNil "TMC_fnc_spawnAttackWave") then {
 };
 
 params [
-    ["_center","defense_center"],
-    ["_minSpawnRadius",500,[0]],
-    ["_maxSpawnRadius",850,[0]],
-    ["_infantryGroupCount",1,[0]],
-    ["_vehicleGroupCount",0,[0]],
-    ["_debugMode","LOG",[""]],
-    ["_waveId",-1,[0]]
+    ["_center", "defense_center"],
+    ["_minSpawnRadius", 500, [0]],
+    ["_maxSpawnRadius", 850, [0]],
+    ["_infantryGroupCount", 1, [0]],
+    ["_vehicleGroupCount", 0, [0]],
+    ["_debugMode", "NONE", [""]],
+    ["_waveId", -1, [0]],
+    ["_targetSide", west, [west]],
+    ["_cqbRadius", 75, [0]]
 ];
 
-private _B1_AT = "JLTS_Droid_B1_AT";
-private _B1_AR = "JLTS_Droid_B1_AR";
-private _B1_SBB3 = "JLTS_Droid_B1_SBB3";
-private _B1_COMMANDER = "JLTS_Droid_B1_Commander";
-private _B1_E5 = "JLTS_Droid_B1_E5";
-private _B1_SNIPER = "JLTS_Droid_B1_Sniper";
-private _B2 = "ls_droid_b2";
-private _DROIDEKA = "ls_droid_droideka";
-private _BX_CAPTAIN = "ls_droid_bx_captain";
-private _BX = "ls_droid_bx";
-private _BX_ASSASSIN = "ls_droid_bx_assassain";
+private _cacheName = "TMC_CloneWars_TemplateCache_v5";
+private _templateCache = missionNamespace getVariable [_cacheName, createHashMap];
 
-private _requiredClasses = [
-    _B1_AT,_B1_AR,_B1_SBB3,_B1_COMMANDER,_B1_E5,_B1_SNIPER,
-    _B2,_DROIDEKA,_BX_CAPTAIN,_BX,_BX_ASSASSIN,
-    "3AS_GAT","3AS_GAT_Light","3AS_N99","3AS_N99_Canister",
-    "ls_vehicle_agtRaptor","3AS_AAT_Red","3AS_MTT",
-    "3AS_Heavy_AAT_Flamer_F","3AS_Heavy_AAT_Shield_F",
-    "3AS_AAT_Desert","3AS_AAT"
-];
+if ((count _templateCache) isEqualTo 0) then {
+    private _B1_AT = "JLTS_Droid_B1_AT";
+    private _B1_AR = "JLTS_Droid_B1_AR";
+    private _B1_SBB3 = "JLTS_Droid_B1_SBB3";
+    private _B1_COMMANDER = "JLTS_Droid_B1_Commander";
+    private _B1_E5 = "JLTS_Droid_B1_E5";
+    private _B1_SNIPER = "JLTS_Droid_B1_Sniper";
+    private _B2 = "ls_droid_b2";
+    private _DROIDEKA = "ls_droid_droideka";
+    private _BX_CAPTAIN = "ls_droid_bx_captain";
+    private _BX = "ls_droid_bx";
+    private _BX_ASSASSIN = "ls_droid_bx_assassain";
 
-private _missing = _requiredClasses select { !(isClass (configFile >> "CfgVehicles" >> _x)) };
-if !(_missing isEqualTo []) exitWith {
-    diag_log format ["[TMC v5] Missing classes: %1",_missing];
+    private _infantryTemplates = [];
+    private _vehicleTemplates = [];
+    private _missingInfantryClasses = [];
+    private _missingVehicleClasses = [];
+
+    private _fnc_addInfantryTemplate = {
+        params ["_template"];
+
+        private _missing = (_template getOrDefault ["units", []]) select {
+            !(isClass (configFile >> "CfgVehicles" >> _x))
+        };
+
+        if (_missing isEqualTo []) then {
+            _infantryTemplates pushBack _template;
+        } else {
+            _missingInfantryClasses append _missing;
+        };
+    };
+
+    private _fnc_addVehicleTemplate = {
+        params ["_name", "_class", "_weight", "_clearance", "_gradient", ["_preferRoad", true]];
+
+        if (isClass (configFile >> "CfgVehicles" >> _class)) then {
+            _vehicleTemplates pushBack createHashMapFromArray [
+                ["name", _name],
+                ["weight", _weight],
+                ["vehicleClass", _class],
+                ["objectClearance", _clearance],
+                ["terrainClearance", 8],
+                ["maxGradient", _gradient],
+                ["visibilityRadius", 15],
+                ["visibilityHeight", 2.7],
+                ["preferRoad", _preferRoad],
+                ["roadSearchRadius", 80]
+            ];
+        } else {
+            _missingVehicleClasses pushBack _class;
+        };
+    };
+
+    [createHashMapFromArray [
+        ["name", "B1 Assault Platoon"],
+        ["weight", 7],
+        ["units", [
+            _B1_COMMANDER,
+            _B1_E5, _B1_E5, _B1_E5, _B1_E5, _B1_E5, _B1_E5, _B1_E5, _B1_E5,
+            _B1_E5, _B1_AR, _B1_AR, _B1_AR, _B1_AT, _B1_AT, _B1_SBB3
+        ]],
+        ["skill", [0.38, 0.52]],
+        ["objectClearance", 10],
+        ["terrainClearance", 3],
+        ["maxGradient", 0.32],
+        ["visibilityRadius", 14]
+    ]] call _fnc_addInfantryTemplate;
+
+    [createHashMapFromArray [
+        ["name", "B1 Fire Support Platoon"],
+        ["weight", 3],
+        ["units", [
+            _B1_COMMANDER,
+            _B1_E5, _B1_E5, _B1_E5, _B1_E5, _B1_E5, _B1_E5,
+            _B1_AR, _B1_AR, _B1_AR, _B1_AR,
+            _B1_AT, _B1_AT, _B1_AT,
+            _B1_SNIPER, _B1_SBB3
+        ]],
+        ["skill", [0.41, 0.56]],
+        ["objectClearance", 11],
+        ["terrainClearance", 3],
+        ["maxGradient", 0.30],
+        ["visibilityRadius", 15]
+    ]] call _fnc_addInfantryTemplate;
+
+    [createHashMapFromArray [
+        ["name", "B2 Assault Platoon"],
+        ["weight", 2],
+        ["units", [
+            _B1_COMMANDER,
+            _B1_E5, _B1_E5, _B1_E5, _B1_E5, _B1_E5, _B1_E5,
+            _B1_AR, _B1_AR, _B1_AT, _B1_AT,
+            _B2, _B2, _B2, _B2, _B2
+        ]],
+        ["skill", [0.44, 0.59]],
+        ["objectClearance", 12],
+        ["terrainClearance", 4],
+        ["maxGradient", 0.27],
+        ["visibilityRadius", 17],
+        ["visibilityHeight", 1.8]
+    ]] call _fnc_addInfantryTemplate;
+
+    [createHashMapFromArray [
+        ["name", "BX Commando Team"],
+        ["weight", 2],
+        ["units", [
+            _BX_CAPTAIN,
+            _BX,
+            _BX,
+            _BX,
+            _BX_ASSASSIN,
+            _BX_ASSASSIN
+        ]],
+        ["skill", [0.58, 0.72]],
+        ["objectClearance", 8],
+        ["terrainClearance", 3],
+        ["maxGradient", 0.35],
+        ["visibilityRadius", 11]
+    ]] call _fnc_addInfantryTemplate;
+
+    [createHashMapFromArray [
+        ["name", "Independent Droideka"],
+        ["weight", 3],
+        ["units", [_DROIDEKA]],
+        ["skill", [0.52, 0.67]],
+        ["objectClearance", 8],
+        ["terrainClearance", 4],
+        ["maxGradient", 0.24],
+        ["visibilityRadius", 10],
+        ["visibilityHeight", 1.8]
+    ]] call _fnc_addInfantryTemplate;
+
+    ["GAT", "3AS_GAT", 3, 18, 0.15] call _fnc_addVehicleTemplate;
+    ["GAT Light", "3AS_GAT_Light", 4, 15, 0.19] call _fnc_addVehicleTemplate;
+    ["N99", "3AS_N99", 3, 17, 0.16] call _fnc_addVehicleTemplate;
+    ["N99 Canister", "3AS_N99_Canister", 2, 17, 0.16] call _fnc_addVehicleTemplate;
+    ["AGT Raptor", "ls_vehicle_agtRaptor", 2, 16, 0.17] call _fnc_addVehicleTemplate;
+    ["AAT Red", "3AS_AAT_Red", 4, 18, 0.15] call _fnc_addVehicleTemplate;
+    ["MTT", "3AS_MTT", 1, 32, 0.10] call _fnc_addVehicleTemplate;
+    ["Heavy AAT Flamer", "3AS_Heavy_AAT_Flamer_F", 1, 22, 0.12] call _fnc_addVehicleTemplate;
+    ["Heavy AAT Shield", "3AS_Heavy_AAT_Shield_F", 1, 22, 0.12] call _fnc_addVehicleTemplate;
+    ["AAT Desert", "3AS_AAT_Desert", 3, 18, 0.15] call _fnc_addVehicleTemplate;
+    ["AAT", "3AS_AAT", 4, 18, 0.15] call _fnc_addVehicleTemplate;
+
+    _missingInfantryClasses = _missingInfantryClasses arrayIntersect _missingInfantryClasses;
+    _missingVehicleClasses = _missingVehicleClasses arrayIntersect _missingVehicleClasses;
+
+    _templateCache = createHashMapFromArray [
+        ["infantryTemplates", _infantryTemplates],
+        ["vehicleTemplates", _vehicleTemplates],
+        ["missingInfantryClasses", _missingInfantryClasses],
+        ["missingVehicleClasses", _missingVehicleClasses]
+    ];
+
+    missionNamespace setVariable [_cacheName, _templateCache];
+
+    if !(_missingInfantryClasses isEqualTo []) then {
+        diag_log format [
+            "[TMC v5] Infantry templates using missing classes were disabled: %1",
+            _missingInfantryClasses
+        ];
+    };
+
+    if !(_missingVehicleClasses isEqualTo []) then {
+        diag_log format [
+            "[TMC v5] Missing vehicle classes were removed from the pool: %1",
+            _missingVehicleClasses
+        ];
+    };
 };
-
-private _b1AssaultPlatoon = createHashMapFromArray [
-    ["name","B1 Assault Platoon"],
-    ["weight",7],
-    ["units",[
-        _B1_COMMANDER,
-        _B1_E5,_B1_E5,_B1_E5,_B1_E5,_B1_E5,_B1_E5,_B1_E5,_B1_E5,
-        _B1_E5,_B1_AR,_B1_AR,_B1_AR,_B1_AT,_B1_AT,_B1_SBB3
-    ]],
-    ["skill",[0.38,0.52]],
-    ["formation","STAG COLUMN"],
-    ["objectClearance",10],
-    ["terrainClearance",3],
-    ["maxGradient",0.32],
-    ["visibilityRadius",14]
-];
-
-private _b1FireSupportPlatoon = createHashMapFromArray [
-    ["name","B1 Fire Support Platoon"],
-    ["weight",3],
-    ["units",[
-        _B1_COMMANDER,
-        _B1_E5,_B1_E5,_B1_E5,_B1_E5,_B1_E5,_B1_E5,
-        _B1_AR,_B1_AR,_B1_AR,_B1_AR,
-        _B1_AT,_B1_AT,_B1_AT,
-        _B1_SNIPER,_B1_SBB3
-    ]],
-    ["skill",[0.41,0.56]],
-    ["formation","STAG COLUMN"],
-    ["objectClearance",11],
-    ["terrainClearance",3],
-    ["maxGradient",0.30],
-    ["visibilityRadius",15]
-];
-
-private _b2AssaultPlatoon = createHashMapFromArray [
-    ["name","B2 Assault Platoon"],
-    ["weight",2],
-    ["units",[
-        _B1_COMMANDER,
-        _B1_E5,_B1_E5,_B1_E5,_B1_E5,_B1_E5,_B1_E5,
-        _B1_AR,_B1_AR,_B1_AT,_B1_AT,
-        _B2,_B2,_B2,_B2,_B2
-    ]],
-    ["skill",[0.44,0.59]],
-    ["formation","STAG COLUMN"],
-    ["objectClearance",12],
-    ["terrainClearance",4],
-    ["maxGradient",0.27],
-    ["visibilityRadius",17],
-    ["visibilityHeight",1.8]
-];
-
-private _commandoTeam = createHashMapFromArray [
-    ["name","BX Commando Team"],
-    ["weight",2],
-    ["units",[
-        _BX_CAPTAIN,
-        _BX,
-        _BX,
-        _BX,
-        _BX_ASSASSIN,
-        _BX_ASSASSIN
-    ]],
-    ["skill",[0.58,0.72]],
-    ["formation","DIAMOND"],
-    ["objectClearance",8],
-    ["terrainClearance",3],
-    ["maxGradient",0.35],
-    ["visibilityRadius",11]
-];
-
-private _droidekaSingle = createHashMapFromArray [
-    ["name","Independent Droideka"],
-    ["weight",3],
-    ["units",[_DROIDEKA]],
-    ["skill",[0.52,0.67]],
-    ["formation","FILE"],
-    ["objectClearance",8],
-    ["terrainClearance",4],
-    ["maxGradient",0.24],
-    ["visibilityRadius",10],
-    ["visibilityHeight",1.8]
-];
-
-private _fnc_vehicleTemplate = {
-    params ["_name","_class","_weight","_clearance","_gradient",["_preferRoad",true]];
-    createHashMapFromArray [
-        ["name",_name],
-        ["weight",_weight],
-        ["vehicleClass",_class],
-        ["objectClearance",_clearance],
-        ["terrainClearance",8],
-        ["maxGradient",_gradient],
-        ["visibilityRadius",15],
-        ["visibilityHeight",2.7],
-        ["preferRoad",_preferRoad],
-        ["roadSearchRadius",80]
-    ]
-};
-
-private _vehicleTemplates = [
-    ["GAT","3AS_GAT",3,18,0.15] call _fnc_vehicleTemplate,
-    ["GAT Light","3AS_GAT_Light",4,15,0.19] call _fnc_vehicleTemplate,
-    ["N99","3AS_N99",3,17,0.16] call _fnc_vehicleTemplate,
-    ["N99 Canister","3AS_N99_Canister",2,17,0.16] call _fnc_vehicleTemplate,
-    ["AGT Raptor","ls_vehicle_agtRaptor",2,16,0.17] call _fnc_vehicleTemplate,
-    ["AAT Red","3AS_AAT_Red",4,18,0.15] call _fnc_vehicleTemplate,
-    ["MTT","3AS_MTT",1,32,0.10] call _fnc_vehicleTemplate,
-    ["Heavy AAT Flamer","3AS_Heavy_AAT_Flamer_F",1,22,0.12] call _fnc_vehicleTemplate,
-    ["Heavy AAT Shield","3AS_Heavy_AAT_Shield_F",1,22,0.12] call _fnc_vehicleTemplate,
-    ["AAT Desert","3AS_AAT_Desert",3,18,0.15] call _fnc_vehicleTemplate,
-    ["AAT","3AS_AAT",4,18,0.15] call _fnc_vehicleTemplate
-];
 
 private _config = createHashMapFromArray [
-    ["center",_center],
-    ["side",east],
-    ["targetSide",west],
-    ["waveId",_waveId],
-    ["minSpawnRadius",_minSpawnRadius],
-    ["maxSpawnRadius",_maxSpawnRadius],
-    ["minPlayerDistance",225],
-    ["visibilityMaxDistance",1500],
-    ["visibilityThreshold",0.05],
-    ["infantryGroupCount",_infantryGroupCount max 0],
-    ["vehicleGroupCount",_vehicleGroupCount max 0],
-    ["infantryTemplates",[
-        _b1AssaultPlatoon,
-        _b1FireSupportPlatoon,
-        _b2AssaultPlatoon,
-        _commandoTeam,
-        _droidekaSingle
-    ]],
-    ["vehicleTemplates",_vehicleTemplates],
-    ["attemptsPerGroup",40],
-    ["groupSeparation",45],
-    ["searchRadius",250],
-    ["cqbRadius",75],
-    ["lambsReinforcement",true],
-    ["lambsKnowledgeSeedChance",0.25],
-    ["ignoreAircraft",true],
-    ["spawnDelay",0.20],
-    ["debugMode",toUpper _debugMode],
-    ["onGroupSpawned",{
-        params ["_group","_kind","_template","_spawnPosition","_vehicle","_config"];
-        private _waveId = _config getOrDefault ["waveId",-1];
-        _group setVariable ["TMC_attackWaveManaged",true,true];
-        _group setVariable ["TMC_attackWaveKind",toUpper _kind,true];
-        _group setVariable ["TMC_attackWaveId",_waveId,true];
-        _group setVariable ["TMC_attackWaveTemplate",_template getOrDefault ["name","UNKNOWN"],true];
+    ["center", _center],
+    ["side", east],
+    ["targetSide", _targetSide],
+    ["waveId", _waveId],
+    ["minSpawnRadius", _minSpawnRadius],
+    ["maxSpawnRadius", _maxSpawnRadius],
+    ["minPlayerDistance", 225],
+    ["visibilityMaxDistance", 1500],
+    ["visibilityThreshold", 0.05],
+    ["infantryGroupCount", _infantryGroupCount max 0],
+    ["vehicleGroupCount", _vehicleGroupCount max 0],
+    ["infantryTemplates", _templateCache getOrDefault ["infantryTemplates", []]],
+    ["vehicleTemplates", _templateCache getOrDefault ["vehicleTemplates", []]],
+    ["attemptsPerGroup", 40],
+    ["groupSeparation", 45],
+    ["searchRadius", 250],
+    ["cqbRadius", _cqbRadius],
+    ["lambsReinforcement", true],
+    ["lambsKnowledgeSeedChance", 0.25],
+    ["spawnDelay", 0],
+    ["debugMode", toUpper _debugMode],
+    ["onGroupSpawned", {
+        params ["_group", "_kind", "_template", "_spawnPosition", "_vehicle", "_config"];
+
+        private _waveId = _config getOrDefault ["waveId", -1];
+        private _kindUpper = toUpper _kind;
+
+        _group setVariable ["TMC_attackWaveManaged", true];
+        _group setVariable ["TMC_attackWaveKind", _kindUpper];
+        _group setVariable ["TMC_attackWaveId", _waveId];
+        _group setVariable [
+            "TMC_attackWaveTemplate",
+            _template getOrDefault ["name", "UNKNOWN"]
+        ];
+
         if (!isNull _vehicle) then {
-            _vehicle setVariable ["TMC_attackWaveVehicle",true,true];
-            _vehicle setVariable ["TMC_attackWaveId",_waveId,true];
+            _vehicle setVariable ["TMC_attackWaveVehicle", true];
+            _vehicle setVariable ["TMC_attackWaveId", _waveId];
+        };
+
+        private _stateName = "TMC_ContinuousDirector_State";
+        private _state = missionNamespace getVariable [_stateName, createHashMap];
+
+        if ((count _state) > 0) then {
+            if (_kindUpper isEqualTo "INFANTRY") then {
+                private _infantryGroups = _state getOrDefault ["infantryGroups", []];
+                _infantryGroups pushBackUnique _group;
+                _state set ["infantryGroups", _infantryGroups];
+
+                private _directorConfig = _state getOrDefault ["config", createHashMap];
+                if (_directorConfig getOrDefault ["ignoreAircraft", true]) then {
+                    {
+                        if (!isNull _x && { alive _x }) then {
+                            _group ignoreTarget _x;
+                        };
+                    } forEach (_state getOrDefault ["knownAircraft", []]);
+                };
+            };
+
+            if (_kindUpper isEqualTo "VEHICLE") then {
+                private _vehicleGroups = _state getOrDefault ["vehicleGroups", []];
+                _vehicleGroups pushBackUnique _group;
+                _state set ["vehicleGroups", _vehicleGroups];
+
+                if (!isNull _vehicle) then {
+                    private _managedVehicles = _state getOrDefault ["managedVehicles", []];
+                    _managedVehicles pushBackUnique _vehicle;
+                    _state set ["managedVehicles", _managedVehicles];
+                };
+            };
+
+            missionNamespace setVariable [_stateName, _state];
         };
     }],
-    ["onComplete",{
-        params ["_result","_config"];
-        diag_log format [
-            "[TMC v5] Package %1 complete. Groups %2 Vehicles %3 Failures %4",
-            _config getOrDefault ["waveId",-1],
-            count (_result get "groups"),
-            count (_result get "vehicles"),
-            _result get "failedSpawns"
-        ];
+    ["onComplete", {
+        params ["_result", "_config"];
+
+        private _failures = _result getOrDefault ["failedSpawns", []];
+        private _debug = toUpper (_config getOrDefault ["debugMode", "NONE"]);
+
+        if (!(_failures isEqualTo []) || { _debug in ["LOG", "MARKERS"] }) then {
+            diag_log format [
+                "[TMC v5] Package %1 complete. Groups %2 Vehicles %3 Failures %4",
+                _config getOrDefault ["waveId", -1],
+                count (_result getOrDefault ["groups", []]),
+                count (_result getOrDefault ["vehicles", []]),
+                _failures
+            ];
+        };
     }]
 ];
 
-private _handle = [_config] spawn TMC_fnc_spawnAttackWave;
-waitUntil { scriptDone _handle };
+[_config] call TMC_fnc_spawnAttackWave;

--- a/TMC_ContinuousDirector_v5/TMC_AttackWave_CloneWars.sqf
+++ b/TMC_ContinuousDirector_v5/TMC_AttackWave_CloneWars.sqf
@@ -1,0 +1,222 @@
+if (!isServer) exitWith {};
+
+if (isNil "TMC_fnc_spawnAttackWave") then {
+    TMC_fnc_spawnAttackWave = compileFinal preprocessFileLineNumbers "TMC_fnc_spawnAttackWave.sqf";
+};
+
+params [
+    ["_center","defense_center"],
+    ["_minSpawnRadius",500,[0]],
+    ["_maxSpawnRadius",850,[0]],
+    ["_infantryGroupCount",1,[0]],
+    ["_vehicleGroupCount",0,[0]],
+    ["_debugMode","LOG",[""]],
+    ["_waveId",-1,[0]]
+];
+
+private _B1_AT = "JLTS_Droid_B1_AT";
+private _B1_AR = "JLTS_Droid_B1_AR";
+private _B1_SBB3 = "JLTS_Droid_B1_SBB3";
+private _B1_COMMANDER = "JLTS_Droid_B1_Commander";
+private _B1_E5 = "JLTS_Droid_B1_E5";
+private _B1_SNIPER = "JLTS_Droid_B1_Sniper";
+private _B2 = "ls_droid_b2";
+private _DROIDEKA = "ls_droid_droideka";
+private _BX_CAPTAIN = "ls_droid_bx_captain";
+private _BX = "ls_droid_bx";
+private _BX_ASSASSIN = "ls_droid_bx_assassain";
+
+private _requiredClasses = [
+    _B1_AT,_B1_AR,_B1_SBB3,_B1_COMMANDER,_B1_E5,_B1_SNIPER,
+    _B2,_DROIDEKA,_BX_CAPTAIN,_BX,_BX_ASSASSIN,
+    "3AS_GAT","3AS_GAT_Light","3AS_N99","3AS_N99_Canister",
+    "ls_vehicle_agtRaptor","3AS_AAT_Red","3AS_MTT",
+    "3AS_Heavy_AAT_Flamer_F","3AS_Heavy_AAT_Shield_F",
+    "3AS_AAT_Desert","3AS_AAT"
+];
+
+private _missing = _requiredClasses select { !(isClass (configFile >> "CfgVehicles" >> _x)) };
+if !(_missing isEqualTo []) exitWith {
+    diag_log format ["[TMC v5] Missing classes: %1",_missing];
+};
+
+private _b1AssaultPlatoon = createHashMapFromArray [
+    ["name","B1 Assault Platoon"],
+    ["weight",7],
+    ["units",[
+        _B1_COMMANDER,
+        _B1_E5,_B1_E5,_B1_E5,_B1_E5,_B1_E5,_B1_E5,_B1_E5,_B1_E5,
+        _B1_E5,_B1_AR,_B1_AR,_B1_AR,_B1_AT,_B1_AT,_B1_SBB3
+    ]],
+    ["skill",[0.38,0.52]],
+    ["formation","STAG COLUMN"],
+    ["objectClearance",10],
+    ["terrainClearance",3],
+    ["maxGradient",0.32],
+    ["visibilityRadius",14]
+];
+
+private _b1FireSupportPlatoon = createHashMapFromArray [
+    ["name","B1 Fire Support Platoon"],
+    ["weight",3],
+    ["units",[
+        _B1_COMMANDER,
+        _B1_E5,_B1_E5,_B1_E5,_B1_E5,_B1_E5,_B1_E5,
+        _B1_AR,_B1_AR,_B1_AR,_B1_AR,
+        _B1_AT,_B1_AT,_B1_AT,
+        _B1_SNIPER,_B1_SBB3
+    ]],
+    ["skill",[0.41,0.56]],
+    ["formation","STAG COLUMN"],
+    ["objectClearance",11],
+    ["terrainClearance",3],
+    ["maxGradient",0.30],
+    ["visibilityRadius",15]
+];
+
+private _b2AssaultPlatoon = createHashMapFromArray [
+    ["name","B2 Assault Platoon"],
+    ["weight",2],
+    ["units",[
+        _B1_COMMANDER,
+        _B1_E5,_B1_E5,_B1_E5,_B1_E5,_B1_E5,_B1_E5,
+        _B1_AR,_B1_AR,_B1_AT,_B1_AT,
+        _B2,_B2,_B2,_B2,_B2
+    ]],
+    ["skill",[0.44,0.59]],
+    ["formation","STAG COLUMN"],
+    ["objectClearance",12],
+    ["terrainClearance",4],
+    ["maxGradient",0.27],
+    ["visibilityRadius",17],
+    ["visibilityHeight",1.8]
+];
+
+private _commandoTeam = createHashMapFromArray [
+    ["name","BX Commando Team"],
+    ["weight",2],
+    ["units",[
+        _BX_CAPTAIN,
+        _BX,
+        _BX,
+        _BX,
+        _BX_ASSASSIN,
+        _BX_ASSASSIN
+    ]],
+    ["skill",[0.58,0.72]],
+    ["formation","DIAMOND"],
+    ["objectClearance",8],
+    ["terrainClearance",3],
+    ["maxGradient",0.35],
+    ["visibilityRadius",11]
+];
+
+private _droidekaPair = createHashMapFromArray [
+    ["name","Droideka Pair"],
+    ["weight",2],
+    ["units",[_DROIDEKA,_DROIDEKA]],
+    ["skill",[0.52,0.67]],
+    ["formation","DIAMOND"],
+    ["objectClearance",9],
+    ["terrainClearance",4],
+    ["maxGradient",0.24],
+    ["visibilityRadius",12],
+    ["visibilityHeight",1.8]
+];
+
+private _droidekaSection = createHashMapFromArray [
+    ["name","Droideka Section"],
+    ["weight",1],
+    ["units",[_DROIDEKA,_DROIDEKA,_DROIDEKA]],
+    ["skill",[0.54,0.69]],
+    ["formation","DIAMOND"],
+    ["objectClearance",10],
+    ["terrainClearance",4],
+    ["maxGradient",0.23],
+    ["visibilityRadius",13],
+    ["visibilityHeight",1.8]
+];
+
+private _fnc_vehicleTemplate = {
+    params ["_name","_class","_weight","_clearance","_gradient",["_preferRoad",true]];
+    createHashMapFromArray [
+        ["name",_name],
+        ["weight",_weight],
+        ["vehicleClass",_class],
+        ["objectClearance",_clearance],
+        ["terrainClearance",8],
+        ["maxGradient",_gradient],
+        ["visibilityRadius",15],
+        ["visibilityHeight",2.7],
+        ["preferRoad",_preferRoad],
+        ["roadSearchRadius",80]
+    ]
+};
+
+private _vehicleTemplates = [
+    ["GAT","3AS_GAT",3,18,0.15] call _fnc_vehicleTemplate,
+    ["GAT Light","3AS_GAT_Light",4,15,0.19] call _fnc_vehicleTemplate,
+    ["N99","3AS_N99",3,17,0.16] call _fnc_vehicleTemplate,
+    ["N99 Canister","3AS_N99_Canister",2,17,0.16] call _fnc_vehicleTemplate,
+    ["AGT Raptor","ls_vehicle_agtRaptor",2,16,0.17] call _fnc_vehicleTemplate,
+    ["AAT Red","3AS_AAT_Red",4,18,0.15] call _fnc_vehicleTemplate,
+    ["MTT","3AS_MTT",1,32,0.10] call _fnc_vehicleTemplate,
+    ["Heavy AAT Flamer","3AS_Heavy_AAT_Flamer_F",1,22,0.12] call _fnc_vehicleTemplate,
+    ["Heavy AAT Shield","3AS_Heavy_AAT_Shield_F",1,22,0.12] call _fnc_vehicleTemplate,
+    ["AAT Desert","3AS_AAT_Desert",3,18,0.15] call _fnc_vehicleTemplate,
+    ["AAT","3AS_AAT",4,18,0.15] call _fnc_vehicleTemplate
+];
+
+private _config = createHashMapFromArray [
+    ["center",_center],
+    ["side",east],
+    ["waveId",_waveId],
+    ["minSpawnRadius",_minSpawnRadius],
+    ["maxSpawnRadius",_maxSpawnRadius],
+    ["minPlayerDistance",225],
+    ["visibilityMaxDistance",1500],
+    ["visibilityThreshold",0.05],
+    ["infantryGroupCount",_infantryGroupCount max 0],
+    ["vehicleGroupCount",_vehicleGroupCount max 0],
+    ["infantryTemplates",[
+        _b1AssaultPlatoon,
+        _b1FireSupportPlatoon,
+        _b2AssaultPlatoon,
+        _commandoTeam,
+        _droidekaPair,
+        _droidekaSection
+    ]],
+    ["vehicleTemplates",_vehicleTemplates],
+    ["attemptsPerGroup",40],
+    ["groupSeparation",45],
+    ["searchRadius",250],
+    ["attackMode","LAMBS"],
+    ["lambsReinforcement",true],
+    ["lambsKnowledgeSeedChance",0.25],
+    ["spawnDelay",0.20],
+    ["debugMode",toUpper _debugMode],
+    ["onGroupSpawned",{
+        params ["_group","_kind","_template","_spawnPosition","_vehicle","_config"];
+        private _waveId = _config getOrDefault ["waveId",-1];
+        _group setVariable ["TMC_attackWaveManaged",true,true];
+        _group setVariable ["TMC_attackWaveKind",toUpper _kind,true];
+        _group setVariable ["TMC_attackWaveId",_waveId,true];
+        if (!isNull _vehicle) then {
+            _vehicle setVariable ["TMC_attackWaveVehicle",true,true];
+            _vehicle setVariable ["TMC_attackWaveId",_waveId,true];
+        };
+    }],
+    ["onComplete",{
+        params ["_result","_config"];
+        diag_log format [
+            "[TMC v5] Package %1 complete. Groups %2 Vehicles %3 Failures %4",
+            _config getOrDefault ["waveId",-1],
+            count (_result get "groups"),
+            count (_result get "vehicles"),
+            _result get "failedSpawns"
+        ];
+    }]
+];
+
+private _handle = [_config] spawn TMC_fnc_spawnAttackWave;
+waitUntil { scriptDone _handle };

--- a/TMC_ContinuousDirector_v5/TMC_AttackWave_CloneWars.sqf
+++ b/TMC_ContinuousDirector_v5/TMC_AttackWave_CloneWars.sqf
@@ -16,7 +16,7 @@ params [
     ["_cqbRadius", 75, [0]]
 ];
 
-private _cacheName = "TMC_CloneWars_TemplateCache_v5";
+private _cacheName = "TMC_CloneWars_TemplateCache_v5_LargeGroups";
 private _templateCache = missionNamespace getVariable [_cacheName, createHashMap];
 
 if ((count _templateCache) isEqualTo 0) then {
@@ -37,14 +37,26 @@ if ((count _templateCache) isEqualTo 0) then {
     private _missingInfantryClasses = [];
     private _missingVehicleClasses = [];
 
+    private _fnc_repeatClass = {
+        params ["_class", "_count"];
+
+        private _result = [];
+        for "_index" from 1 to _count do {
+            _result pushBack _class;
+        };
+        _result
+    };
+
     private _fnc_addInfantryTemplate = {
         params ["_template"];
 
-        private _missing = (_template getOrDefault ["units", []]) select {
+        private _units = _template getOrDefault ["units", []];
+        private _missing = _units select {
             !(isClass (configFile >> "CfgVehicles" >> _x))
         };
 
         if (_missing isEqualTo []) then {
+            _template set ["unitCount", count _units];
             _infantryTemplates pushBack _template;
         } else {
             _missingInfantryClasses append _missing;
@@ -72,58 +84,62 @@ if ((count _templateCache) isEqualTo 0) then {
         };
     };
 
+    private _b1AssaultUnits = [_B1_COMMANDER];
+    _b1AssaultUnits append ([_B1_E5, 27] call _fnc_repeatClass);
+    _b1AssaultUnits append ([_B1_AR, 6] call _fnc_repeatClass);
+    _b1AssaultUnits append ([_B1_AT, 4] call _fnc_repeatClass);
+    _b1AssaultUnits append ([_B1_SBB3, 2] call _fnc_repeatClass);
+
     [createHashMapFromArray [
-        ["name", "B1 Assault Platoon"],
-        ["weight", 7],
-        ["units", [
-            _B1_COMMANDER,
-            _B1_E5, _B1_E5, _B1_E5, _B1_E5, _B1_E5, _B1_E5, _B1_E5, _B1_E5,
-            _B1_E5, _B1_AR, _B1_AR, _B1_AR, _B1_AT, _B1_AT, _B1_SBB3
-        ]],
+        ["name", "B1 Assault Battalion Group (40)"],
+        ["weight", 12],
+        ["units", _b1AssaultUnits],
         ["skill", [0.38, 0.52]],
-        ["objectClearance", 10],
-        ["terrainClearance", 3],
-        ["maxGradient", 0.32],
-        ["visibilityRadius", 14]
+        ["objectClearance", 18],
+        ["terrainClearance", 5],
+        ["maxGradient", 0.28],
+        ["visibilityRadius", 22]
     ]] call _fnc_addInfantryTemplate;
 
+    private _b1FireSupportUnits = [_B1_COMMANDER];
+    _b1FireSupportUnits append ([_B1_E5, 14] call _fnc_repeatClass);
+    _b1FireSupportUnits append ([_B1_AR, 8] call _fnc_repeatClass);
+    _b1FireSupportUnits append ([_B1_AT, 4] call _fnc_repeatClass);
+    _b1FireSupportUnits append ([_B1_SNIPER, 2] call _fnc_repeatClass);
+    _b1FireSupportUnits append ([_B1_SBB3, 1] call _fnc_repeatClass);
+
     [createHashMapFromArray [
-        ["name", "B1 Fire Support Platoon"],
-        ["weight", 3],
-        ["units", [
-            _B1_COMMANDER,
-            _B1_E5, _B1_E5, _B1_E5, _B1_E5, _B1_E5, _B1_E5,
-            _B1_AR, _B1_AR, _B1_AR, _B1_AR,
-            _B1_AT, _B1_AT, _B1_AT,
-            _B1_SNIPER, _B1_SBB3
-        ]],
+        ["name", "B1 Fire Support Company (30)"],
+        ["weight", 9],
+        ["units", _b1FireSupportUnits],
         ["skill", [0.41, 0.56]],
-        ["objectClearance", 11],
-        ["terrainClearance", 3],
-        ["maxGradient", 0.30],
-        ["visibilityRadius", 15]
+        ["objectClearance", 16],
+        ["terrainClearance", 4],
+        ["maxGradient", 0.28],
+        ["visibilityRadius", 20]
     ]] call _fnc_addInfantryTemplate;
 
+    private _mixedAssaultUnits = [_B1_COMMANDER];
+    _mixedAssaultUnits append ([_B1_E5, 9] call _fnc_repeatClass);
+    _mixedAssaultUnits append ([_B1_AR, 3] call _fnc_repeatClass);
+    _mixedAssaultUnits append ([_B1_AT, 2] call _fnc_repeatClass);
+    _mixedAssaultUnits append ([_B2, 5] call _fnc_repeatClass);
+
     [createHashMapFromArray [
-        ["name", "B2 Assault Platoon"],
-        ["weight", 2],
-        ["units", [
-            _B1_COMMANDER,
-            _B1_E5, _B1_E5, _B1_E5, _B1_E5, _B1_E5, _B1_E5,
-            _B1_AR, _B1_AR, _B1_AT, _B1_AT,
-            _B2, _B2, _B2, _B2, _B2
-        ]],
+        ["name", "B1/B2 Assault Platoon (20)"],
+        ["weight", 7],
+        ["units", _mixedAssaultUnits],
         ["skill", [0.44, 0.59]],
-        ["objectClearance", 12],
+        ["objectClearance", 14],
         ["terrainClearance", 4],
         ["maxGradient", 0.27],
-        ["visibilityRadius", 17],
+        ["visibilityRadius", 18],
         ["visibilityHeight", 1.8]
     ]] call _fnc_addInfantryTemplate;
 
     [createHashMapFromArray [
-        ["name", "BX Commando Team"],
-        ["weight", 2],
+        ["name", "BX Commando Team (6)"],
+        ["weight", 1],
         ["units", [
             _BX_CAPTAIN,
             _BX,
@@ -140,8 +156,20 @@ if ((count _templateCache) isEqualTo 0) then {
     ]] call _fnc_addInfantryTemplate;
 
     [createHashMapFromArray [
-        ["name", "Independent Droideka"],
-        ["weight", 3],
+        ["name", "B2 Hunter Cell (3)"],
+        ["weight", 1],
+        ["units", [_B2, _B2, _B2]],
+        ["skill", [0.50, 0.65]],
+        ["objectClearance", 8],
+        ["terrainClearance", 4],
+        ["maxGradient", 0.28],
+        ["visibilityRadius", 10],
+        ["visibilityHeight", 1.8]
+    ]] call _fnc_addInfantryTemplate;
+
+    [createHashMapFromArray [
+        ["name", "Independent Droideka (1)"],
+        ["weight", 1],
         ["units", [_DROIDEKA]],
         ["skill", [0.52, 0.67]],
         ["objectClearance", 8],

--- a/TMC_ContinuousDirector_v5/TMC_AttackWave_CloneWars.sqf
+++ b/TMC_ContinuousDirector_v5/TMC_AttackWave_CloneWars.sqf
@@ -16,7 +16,7 @@ params [
     ["_cqbRadius", 75, [0]]
 ];
 
-private _cacheName = "TMC_CloneWars_TemplateCache_v5_LargeGroups";
+private _cacheName = "TMC_CloneWars_TemplateCache_v5_MergeGroups";
 private _templateCache = missionNamespace getVariable [_cacheName, createHashMap];
 
 if ((count _templateCache) isEqualTo 0) then {
@@ -85,56 +85,62 @@ if ((count _templateCache) isEqualTo 0) then {
     };
 
     private _b1AssaultUnits = [_B1_COMMANDER];
-    _b1AssaultUnits append ([_B1_E5, 27] call _fnc_repeatClass);
-    _b1AssaultUnits append ([_B1_AR, 6] call _fnc_repeatClass);
-    _b1AssaultUnits append ([_B1_AT, 4] call _fnc_repeatClass);
-    _b1AssaultUnits append ([_B1_SBB3, 2] call _fnc_repeatClass);
+    _b1AssaultUnits append ([_B1_E5, 20] call _fnc_repeatClass);
+    _b1AssaultUnits append ([_B1_AR, 5] call _fnc_repeatClass);
+    _b1AssaultUnits append ([_B1_AT, 3] call _fnc_repeatClass);
+    _b1AssaultUnits append ([_B1_SBB3, 1] call _fnc_repeatClass);
 
     [createHashMapFromArray [
-        ["name", "B1 Assault Battalion Group (40)"],
+        ["name", "B1 Assault Company (30)"],
         ["weight", 12],
         ["units", _b1AssaultUnits],
         ["skill", [0.38, 0.52]],
-        ["objectClearance", 18],
-        ["terrainClearance", 5],
-        ["maxGradient", 0.28],
-        ["visibilityRadius", 22]
+        ["objectClearance", 16],
+        ["terrainClearance", 4],
+        ["maxGradient", 0.29],
+        ["visibilityRadius", 20],
+        ["allowMerge", true],
+        ["maximumMergedSize", 30]
     ]] call _fnc_addInfantryTemplate;
 
     private _b1FireSupportUnits = [_B1_COMMANDER];
-    _b1FireSupportUnits append ([_B1_E5, 14] call _fnc_repeatClass);
-    _b1FireSupportUnits append ([_B1_AR, 8] call _fnc_repeatClass);
-    _b1FireSupportUnits append ([_B1_AT, 4] call _fnc_repeatClass);
-    _b1FireSupportUnits append ([_B1_SNIPER, 2] call _fnc_repeatClass);
+    _b1FireSupportUnits append ([_B1_E5, 9] call _fnc_repeatClass);
+    _b1FireSupportUnits append ([_B1_AR, 5] call _fnc_repeatClass);
+    _b1FireSupportUnits append ([_B1_AT, 3] call _fnc_repeatClass);
+    _b1FireSupportUnits append ([_B1_SNIPER, 1] call _fnc_repeatClass);
     _b1FireSupportUnits append ([_B1_SBB3, 1] call _fnc_repeatClass);
 
     [createHashMapFromArray [
-        ["name", "B1 Fire Support Company (30)"],
+        ["name", "B1 Fire Support Platoon (20)"],
         ["weight", 9],
         ["units", _b1FireSupportUnits],
         ["skill", [0.41, 0.56]],
-        ["objectClearance", 16],
+        ["objectClearance", 14],
         ["terrainClearance", 4],
-        ["maxGradient", 0.28],
-        ["visibilityRadius", 20]
+        ["maxGradient", 0.30],
+        ["visibilityRadius", 18],
+        ["allowMerge", true],
+        ["maximumMergedSize", 30]
     ]] call _fnc_addInfantryTemplate;
 
     private _mixedAssaultUnits = [_B1_COMMANDER];
-    _mixedAssaultUnits append ([_B1_E5, 9] call _fnc_repeatClass);
-    _mixedAssaultUnits append ([_B1_AR, 3] call _fnc_repeatClass);
-    _mixedAssaultUnits append ([_B1_AT, 2] call _fnc_repeatClass);
-    _mixedAssaultUnits append ([_B2, 5] call _fnc_repeatClass);
+    _mixedAssaultUnits append ([_B1_E5, 4] call _fnc_repeatClass);
+    _mixedAssaultUnits append ([_B1_AR, 1] call _fnc_repeatClass);
+    _mixedAssaultUnits append ([_B1_AT, 1] call _fnc_repeatClass);
+    _mixedAssaultUnits append ([_B2, 3] call _fnc_repeatClass);
 
     [createHashMapFromArray [
-        ["name", "B1/B2 Assault Platoon (20)"],
+        ["name", "B1/B2 Assault Squad (10)"],
         ["weight", 7],
         ["units", _mixedAssaultUnits],
         ["skill", [0.44, 0.59]],
-        ["objectClearance", 14],
+        ["objectClearance", 11],
         ["terrainClearance", 4],
-        ["maxGradient", 0.27],
-        ["visibilityRadius", 18],
-        ["visibilityHeight", 1.8]
+        ["maxGradient", 0.31],
+        ["visibilityRadius", 14],
+        ["visibilityHeight", 1.8],
+        ["allowMerge", true],
+        ["maximumMergedSize", 30]
     ]] call _fnc_addInfantryTemplate;
 
     [createHashMapFromArray [
@@ -152,7 +158,9 @@ if ((count _templateCache) isEqualTo 0) then {
         ["objectClearance", 8],
         ["terrainClearance", 3],
         ["maxGradient", 0.35],
-        ["visibilityRadius", 11]
+        ["visibilityRadius", 11],
+        ["allowMerge", false],
+        ["maximumMergedSize", 6]
     ]] call _fnc_addInfantryTemplate;
 
     [createHashMapFromArray [
@@ -164,7 +172,9 @@ if ((count _templateCache) isEqualTo 0) then {
         ["terrainClearance", 4],
         ["maxGradient", 0.28],
         ["visibilityRadius", 10],
-        ["visibilityHeight", 1.8]
+        ["visibilityHeight", 1.8],
+        ["allowMerge", false],
+        ["maximumMergedSize", 3]
     ]] call _fnc_addInfantryTemplate;
 
     [createHashMapFromArray [
@@ -176,7 +186,9 @@ if ((count _templateCache) isEqualTo 0) then {
         ["terrainClearance", 4],
         ["maxGradient", 0.24],
         ["visibilityRadius", 10],
-        ["visibilityHeight", 1.8]
+        ["visibilityHeight", 1.8],
+        ["allowMerge", false],
+        ["maximumMergedSize", 1]
     ]] call _fnc_addInfantryTemplate;
 
     ["GAT", "3AS_GAT", 3, 18, 0.15] call _fnc_addVehicleTemplate;
@@ -252,6 +264,14 @@ private _config = createHashMapFromArray [
         _group setVariable [
             "TMC_attackWaveTemplate",
             _template getOrDefault ["name", "UNKNOWN"]
+        ];
+        _group setVariable [
+            "TMC_attackWaveAllowMerge",
+            _template getOrDefault ["allowMerge", false]
+        ];
+        _group setVariable [
+            "TMC_attackWaveMaximumMergedSize",
+            round (_template getOrDefault ["maximumMergedSize", 30])
         ];
 
         if (!isNull _vehicle) then {

--- a/TMC_ContinuousDirector_v5/TMC_AttackWave_CloneWars.sqf
+++ b/TMC_ContinuousDirector_v5/TMC_AttackWave_CloneWars.sqf
@@ -111,29 +111,16 @@ private _commandoTeam = createHashMapFromArray [
     ["visibilityRadius",11]
 ];
 
-private _droidekaPair = createHashMapFromArray [
-    ["name","Droideka Pair"],
-    ["weight",2],
-    ["units",[_DROIDEKA,_DROIDEKA]],
+private _droidekaSingle = createHashMapFromArray [
+    ["name","Independent Droideka"],
+    ["weight",3],
+    ["units",[_DROIDEKA]],
     ["skill",[0.52,0.67]],
-    ["formation","DIAMOND"],
-    ["objectClearance",9],
+    ["formation","FILE"],
+    ["objectClearance",8],
     ["terrainClearance",4],
     ["maxGradient",0.24],
-    ["visibilityRadius",12],
-    ["visibilityHeight",1.8]
-];
-
-private _droidekaSection = createHashMapFromArray [
-    ["name","Droideka Section"],
-    ["weight",1],
-    ["units",[_DROIDEKA,_DROIDEKA,_DROIDEKA]],
-    ["skill",[0.54,0.69]],
-    ["formation","DIAMOND"],
-    ["objectClearance",10],
-    ["terrainClearance",4],
-    ["maxGradient",0.23],
-    ["visibilityRadius",13],
+    ["visibilityRadius",10],
     ["visibilityHeight",1.8]
 ];
 
@@ -170,6 +157,7 @@ private _vehicleTemplates = [
 private _config = createHashMapFromArray [
     ["center",_center],
     ["side",east],
+    ["targetSide",west],
     ["waveId",_waveId],
     ["minSpawnRadius",_minSpawnRadius],
     ["maxSpawnRadius",_maxSpawnRadius],
@@ -183,16 +171,16 @@ private _config = createHashMapFromArray [
         _b1FireSupportPlatoon,
         _b2AssaultPlatoon,
         _commandoTeam,
-        _droidekaPair,
-        _droidekaSection
+        _droidekaSingle
     ]],
     ["vehicleTemplates",_vehicleTemplates],
     ["attemptsPerGroup",40],
     ["groupSeparation",45],
     ["searchRadius",250],
-    ["attackMode","LAMBS"],
+    ["cqbRadius",75],
     ["lambsReinforcement",true],
     ["lambsKnowledgeSeedChance",0.25],
+    ["ignoreAircraft",true],
     ["spawnDelay",0.20],
     ["debugMode",toUpper _debugMode],
     ["onGroupSpawned",{
@@ -201,6 +189,7 @@ private _config = createHashMapFromArray [
         _group setVariable ["TMC_attackWaveManaged",true,true];
         _group setVariable ["TMC_attackWaveKind",toUpper _kind,true];
         _group setVariable ["TMC_attackWaveId",_waveId,true];
+        _group setVariable ["TMC_attackWaveTemplate",_template getOrDefault ["name","UNKNOWN"],true];
         if (!isNull _vehicle) then {
             _vehicle setVariable ["TMC_attackWaveVehicle",true,true];
             _vehicle setVariable ["TMC_attackWaveId",_waveId,true];

--- a/TMC_ContinuousDirector_v5/TMC_CfgFunctions.hpp
+++ b/TMC_ContinuousDirector_v5/TMC_CfgFunctions.hpp
@@ -1,0 +1,11 @@
+class TMC
+{
+    class AttackWave
+    {
+        file = ".";
+        class spawnAttackWave
+        {
+            file = "TMC_fnc_spawnAttackWave.sqf";
+        };
+    };
+};

--- a/TMC_ContinuousDirector_v5/TMC_ContinuousDirector.sqf
+++ b/TMC_ContinuousDirector_v5/TMC_ContinuousDirector.sqf
@@ -535,6 +535,8 @@ private _fnc_evaluate = {
 
                     _destinationGroup setVariable ["TMC_attackWaveAllowMerge", true];
                     _destinationGroup setVariable ["TMC_attackWaveTemplate", "Merged regular infantry"];
+                    _destinationGroup setVariable ["TMC_lastLeaderPosition", getPosATL _destinationLeader];
+                    _destinationGroup setVariable ["TMC_lastProgressTime", _now];
 
                     if ((units _sourceGroup) isEqualTo []) then {
                         deleteGroup _sourceGroup;

--- a/TMC_ContinuousDirector_v5/TMC_ContinuousDirector.sqf
+++ b/TMC_ContinuousDirector_v5/TMC_ContinuousDirector.sqf
@@ -32,8 +32,19 @@ if (_mode in ["STOP", "PAUSE", "RESUME", "STATUS"]) exitWith {
                 removeMissionEventHandler ["EntityCreated", _entityCreatedEH];
             };
 
+            {
+                if (!scriptDone _x) then {
+                    terminate _x;
+                };
+            } forEach (
+                (_state getOrDefault ["infantryHandles", []])
+                + (_state getOrDefault ["vehicleHandles", []])
+            );
+
             _state set ["pfhHandle", -1];
             _state set ["entityCreatedEH", -1];
+            _state set ["infantryHandles", []];
+            _state set ["vehicleHandles", []];
             missionNamespace setVariable [_stateName, _state];
             diag_log "[TMC v5 Director] Stopped.";
         };
@@ -78,6 +89,7 @@ private _defaults = createHashMapFromArray [
     ["scalingMode", "AREA"],
     ["scalingSide", west],
     ["scalingRadius", 300],
+    ["scalingEvaluationInterval", 5],
     ["minimumScalingUnits", 1],
     ["enemySide", east],
     ["enemyRatio", 3],
@@ -134,13 +146,15 @@ private _existingVehicleGroups = _existingManagedGroups select {
 };
 
 private _existingManagedVehicles = vehicles select {
-    alive _x
-    && { _x getVariable ["TMC_attackWaveVehicle", false] }
-    && { crew _x findIf { alive _x } >= 0 }
+    alive _x && { _x getVariable ["TMC_attackWaveVehicle", false] }
 };
 
-private _knownAircraft = vehicles select {
-    alive _x && { _x isKindOf "Air" }
+private _knownAircraft = if (_config get "ignoreAircraft") then {
+    vehicles select {
+        alive _x && { _x isKindOf "Air" }
+    }
+} else {
+    []
 };
 
 private _now = diag_tickTime;
@@ -160,6 +174,7 @@ private _state = createHashMapFromArray [
     ["packageNumber", 0],
     ["retaskedTotal", 0],
     ["stuckTotal", 0],
+    ["nextScalingCheck", _now + (_config get "initialDelay")],
     ["nextInfantryCheck", _now + (_config get "initialDelay")],
     ["nextVehicleCheck", _now + (_config get "initialDelay") + (_config get "vehicleEvaluationOffset")],
     ["nextBehaviorCheck", _now + (_config get "initialDelay") + 5],
@@ -178,38 +193,39 @@ if (_config get "ignoreAircraft") then {
     } forEach _existingInfantryGroups;
 };
 
-private _entityCreatedEH = addMissionEventHandler ["EntityCreated", {
-    params ["_entity"];
+private _entityCreatedEH = -1;
 
-    if (
-        !isServer
-        || { isNull _entity }
-        || { !(_entity isKindOf "Air") }
-    ) exitWith {};
+if (_config get "ignoreAircraft") then {
+    _entityCreatedEH = addMissionEventHandler ["EntityCreated", {
+        params ["_entity"];
 
-    private _stateName = "TMC_ContinuousDirector_State";
-    private _state = missionNamespace getVariable [_stateName, createHashMap];
+        if (
+            !isServer
+            || { isNull _entity }
+            || { !(_entity isKindOf "Air") }
+        ) exitWith {};
 
-    if (
-        (count _state) isEqualTo 0
-        || { !(_state getOrDefault ["running", false]) }
-    ) exitWith {};
+        private _stateName = "TMC_ContinuousDirector_State";
+        private _state = missionNamespace getVariable [_stateName, createHashMap];
 
-    private _config = _state getOrDefault ["config", createHashMap];
-    if !(_config getOrDefault ["ignoreAircraft", true]) exitWith {};
+        if (
+            (count _state) isEqualTo 0
+            || { !(_state getOrDefault ["running", false]) }
+        ) exitWith {};
 
-    private _knownAircraft = _state getOrDefault ["knownAircraft", []];
-    _knownAircraft pushBackUnique _entity;
-    _state set ["knownAircraft", _knownAircraft];
+        private _knownAircraft = _state getOrDefault ["knownAircraft", []];
+        _knownAircraft pushBackUnique _entity;
+        _state set ["knownAircraft", _knownAircraft];
 
-    {
-        if (!isNull _x && { units _x findIf { alive _x } >= 0 }) then {
-            _x ignoreTarget _entity;
-        };
-    } forEach (_state getOrDefault ["infantryGroups", []]);
+        {
+            if (!isNull _x && { units _x findIf { alive _x } >= 0 }) then {
+                _x ignoreTarget _entity;
+            };
+        } forEach (_state getOrDefault ["infantryGroups", []]);
 
-    missionNamespace setVariable [_stateName, _state];
-}];
+        missionNamespace setVariable [_stateName, _state];
+    }];
+};
 
 _state set ["entityCreatedEH", _entityCreatedEH];
 missionNamespace setVariable [_stateName, _state];
@@ -234,13 +250,21 @@ private _fnc_evaluate = {
     private _now = diag_tickTime;
     private _debugMode = toUpper (_config getOrDefault ["debugMode", "NONE"]);
 
+    private _scalingDue = _now >= (_state get "nextScalingCheck");
     private _infantryDue = _now >= (_state get "nextInfantryCheck");
     private _vehicleDue = _now >= (_state get "nextVehicleCheck");
     private _behaviorDue = _now >= (_state get "nextBehaviorCheck");
     private _statusDue = _debugMode in ["LOG", "MARKERS"]
         && { _now >= (_state get "nextStatusLog") };
 
-    if !(_infantryDue || _vehicleDue || _behaviorDue || _statusDue) exitWith {};
+    if !(_scalingDue || _infantryDue || _vehicleDue || _behaviorDue || _statusDue) exitWith {};
+
+    if (_scalingDue) then {
+        _state set [
+            "nextScalingCheck",
+            _now + (_config get "scalingEvaluationInterval")
+        ];
+    };
 
     if (_infantryDue) then {
         _state set [
@@ -284,9 +308,10 @@ private _fnc_evaluate = {
         !isNull _x && { units _x findIf { alive _x } >= 0 }
     };
     private _managedVehicles = (_state getOrDefault ["managedVehicles", []]) select {
-        !isNull _x
-        && { alive _x }
-        && { crew _x findIf { alive _x } >= 0 }
+        !isNull _x && { alive _x }
+    };
+    private _activeVehicles = _managedVehicles select {
+        crew _x findIf { alive _x } >= 0
     };
     private _knownAircraft = (_state getOrDefault ["knownAircraft", []]) select {
         !isNull _x && { alive _x }
@@ -301,9 +326,17 @@ private _fnc_evaluate = {
 
     private _center = _state get "center";
     private _centerPos = _center call CBA_fnc_getPos;
+
     if ((count _centerPos) < 2) exitWith {
         diag_log "[TMC v5 Director] Center reference became invalid. Director stopped.";
+
+        private _entityCreatedEH = _state getOrDefault ["entityCreatedEH", -1];
+        if (_entityCreatedEH >= 0) then {
+            removeMissionEventHandler ["EntityCreated", _entityCreatedEH];
+        };
+
         _state set ["running", false];
+        _state set ["entityCreatedEH", -1];
         missionNamespace setVariable [_stateName, _state];
         [_pfhHandle] call CBA_fnc_removePerFrameHandler;
     };
@@ -316,7 +349,7 @@ private _fnc_evaluate = {
     private _scalingSide = _config get "scalingSide";
     private _enemySide = _config get "enemySide";
 
-    if (_infantryDue || _vehicleDue || _statusDue) then {
+    if (_scalingDue) then {
         private _sideUnits = allUnits select {
             alive _x && { side group _x isEqualTo _scalingSide }
         };
@@ -381,7 +414,7 @@ private _fnc_evaluate = {
 
     private _effectiveInfantry = _infantryCount
         + (count _infantryHandles * round (_config get "estimatedInfantryPerGroup"));
-    private _effectiveVehicles = count _managedVehicles + count _vehicleHandles;
+    private _effectiveVehicles = count _activeVehicles + count _vehicleHandles;
     private _infantryDeficit = (_desiredInfantry - _effectiveInfantry) max 0;
     private _vehicleDeficit = (_desiredVehicles - _effectiveVehicles) max 0;
 
@@ -467,7 +500,20 @@ private _fnc_evaluate = {
                         (_config get "cqbRadius") max 25
                     );
                     _group setCurrentWaypoint _waypoint;
+
+                    if (!_enemyNearby && { !_activeCQB }) then {
+                        _group move _targetPos;
+                    };
+
                     _group setVariable ["TMC_attackWaypoint", _waypoint];
+                    _group setVariable ["TMC_attackTarget", _target];
+                    _group setVariable ["TMC_attackTargetPosition", _targetPos];
+                    _group setVariable ["TMC_lastLeaderPosition", getPosATL _leader];
+                    _group setVariable ["TMC_lastProgressTime", _now];
+                    _group setVariable [
+                        "TMC_lastTargetDistance",
+                        _leader distance2D _targetPos
+                    ];
                     _retaskedThisCheck = _retaskedThisCheck + 1;
                 };
 
@@ -494,6 +540,12 @@ private _fnc_evaluate = {
 
                     _group setVariable ["TMC_attackTarget", _target];
                     _group setVariable ["TMC_attackTargetPosition", _targetPos];
+                    _group setVariable ["TMC_lastLeaderPosition", getPosATL _leader];
+                    _group setVariable ["TMC_lastProgressTime", _now];
+                    _group setVariable [
+                        "TMC_lastTargetDistance",
+                        _leader distance2D _targetPos
+                    ];
                     _retaskedThisCheck = _retaskedThisCheck + 1;
                 };
 
@@ -690,7 +742,7 @@ private _fnc_evaluate = {
         ["desiredInfantry", _desiredInfantry],
         ["effectiveInfantry", _effectiveInfantry],
         ["infantryDeficit", _infantryDeficit],
-        ["vehicles", count _managedVehicles],
+        ["vehicles", count _activeVehicles],
         ["desiredVehicles", _desiredVehicles],
         ["effectiveVehicles", _effectiveVehicles],
         ["vehicleDeficit", _vehicleDeficit],
@@ -736,7 +788,8 @@ _state set ["pfhHandle", _pfhHandle];
 missionNamespace setVariable [_stateName, _state];
 
 diag_log format [
-    "[TMC v5 Director] Started. Infantry %1:1 every %2s. Vehicles 1:%3 every %4s with %5s offset. Behavior checks every %6s.",
+    "[TMC v5 Director] Started. Scaling every %1s. Infantry %2:1 every %3s. Vehicles 1:%4 every %5s with %6s offset. Behavior checks every %7s.",
+    _config get "scalingEvaluationInterval",
     _config get "enemyRatio",
     _config get "infantryEvaluationInterval",
     _config get "scalingUnitsPerVehicle",

--- a/TMC_ContinuousDirector_v5/TMC_ContinuousDirector.sqf
+++ b/TMC_ContinuousDirector_v5/TMC_ContinuousDirector.sqf
@@ -1,220 +1,423 @@
 if (!isServer) exitWith {};
 
 params [
-    ["_mode","START",[""]],
-    ["_center",objNull],
-    ["_overrides",createHashMap]
+    ["_mode", "START", [""]],
+    ["_center", objNull],
+    ["_overrides", createHashMap]
 ];
 
 _mode = toUpper _mode;
 private _stateName = "TMC_ContinuousDirector_State";
 
-if (_mode in ["STOP","PAUSE","RESUME","STATUS"]) exitWith {
-    private _state = missionNamespace getVariable [_stateName,createHashMap];
-    if ((count _state) isEqualTo 0) exitWith {};
+if (_mode in ["STOP", "PAUSE", "RESUME", "STATUS"]) exitWith {
+    private _state = missionNamespace getVariable [_stateName, createHashMap];
+
+    if ((count _state) isEqualTo 0) exitWith {
+        if (_mode isEqualTo "STATUS") then {
+            diag_log "[TMC v5 Director] Director state was not found.";
+        };
+    };
+
     switch (_mode) do {
         case "STOP": {
-            _state set ["running",false];
-            private _handle = _state getOrDefault ["pfhHandle",-1];
-            if (_handle >= 0) then { [_handle] call CBA_fnc_removePerFrameHandler };
-            missionNamespace setVariable [_stateName,_state];
+            _state set ["running", false];
+
+            private _pfhHandle = _state getOrDefault ["pfhHandle", -1];
+            if (_pfhHandle >= 0) then {
+                [_pfhHandle] call CBA_fnc_removePerFrameHandler;
+            };
+
+            private _entityCreatedEH = _state getOrDefault ["entityCreatedEH", -1];
+            if (_entityCreatedEH >= 0) then {
+                removeMissionEventHandler ["EntityCreated", _entityCreatedEH];
+            };
+
+            _state set ["pfhHandle", -1];
+            _state set ["entityCreatedEH", -1];
+            missionNamespace setVariable [_stateName, _state];
+            diag_log "[TMC v5 Director] Stopped.";
         };
+
         case "PAUSE": {
-            _state set ["paused",true];
-            missionNamespace setVariable [_stateName,_state];
+            _state set ["paused", true];
+            missionNamespace setVariable [_stateName, _state];
+            diag_log "[TMC v5 Director] Paused.";
         };
+
         case "RESUME": {
-            _state set ["paused",false];
-            missionNamespace setVariable [_stateName,_state];
+            _state set ["paused", false];
+            missionNamespace setVariable [_stateName, _state];
+            diag_log "[TMC v5 Director] Resumed.";
         };
+
         case "STATUS": {
-            diag_log format ["[TMC v5 Director] %1",_state getOrDefault ["snapshot",createHashMap]];
+            diag_log format [
+                "[TMC v5 Director] %1",
+                _state getOrDefault ["snapshot", createHashMap]
+            ];
         };
     };
 };
 
 if !(_mode isEqualTo "START") exitWith {};
-if !(_overrides isEqualType createHashMap) exitWith {};
+if !(_overrides isEqualType createHashMap) exitWith {
+    diag_log "[TMC v5 Director] START rejected because overrides were not a HashMap.";
+};
 
-private _old = missionNamespace getVariable [_stateName,createHashMap];
-if ((count _old) > 0 && {_old getOrDefault ["running",false]}) exitWith {
+private _oldState = missionNamespace getVariable [_stateName, createHashMap];
+if ((count _oldState) > 0 && { _oldState getOrDefault ["running", false] }) exitWith {
     diag_log "[TMC v5 Director] START ignored because the director is already running.";
 };
 
+private _oldEntityCreatedEH = _oldState getOrDefault ["entityCreatedEH", -1];
+if (_oldEntityCreatedEH >= 0) then {
+    removeMissionEventHandler ["EntityCreated", _oldEntityCreatedEH];
+};
+
 private _defaults = createHashMapFromArray [
-    ["scalingMode","AREA"],
-    ["scalingSide",west],
-    ["scalingRadius",300],
-    ["minimumScalingUnits",1],
-    ["enemySide",east],
-    ["enemyRatio",3],
-    ["scalingUnitsPerVehicle",10],
-    ["initialDelay",1],
-    ["infantryEvaluationInterval",5],
-    ["vehicleEvaluationInterval",10],
-    ["vehicleEvaluationOffset",2.5],
-    ["behaviorEvaluationInterval",20],
-    ["stuckTimeout",75],
-    ["stuckMovementDistance",20],
-    ["targetMoveThreshold",35],
-    ["maxDesiredInfantry",-1],
-    ["hardInfantryCap",450],
-    ["maxActiveVehicles",20],
-    ["maxManagedInfantryGroups",48],
-    ["maxManagedVehicleGroups",24],
-    ["maxManagedGroups",72],
-    ["infantryMinimumServerFPS",15],
-    ["vehicleMinimumServerFPS",15],
-    ["estimatedInfantryPerGroup",12],
-    ["waveScript","TMC_AttackWave_CloneWars.sqf"],
-    ["minSpawnRadius",500],
-    ["maxSpawnRadius",850],
-    ["debugMode","LOG"]
+    ["scalingMode", "AREA"],
+    ["scalingSide", west],
+    ["scalingRadius", 300],
+    ["minimumScalingUnits", 1],
+    ["enemySide", east],
+    ["enemyRatio", 3],
+    ["scalingUnitsPerVehicle", 10],
+    ["initialDelay", 1],
+    ["infantryEvaluationInterval", 5],
+    ["vehicleEvaluationInterval", 10],
+    ["vehicleEvaluationOffset", 2.5],
+    ["behaviorEvaluationInterval", 20],
+    ["statusLogInterval", 60],
+    ["stuckTimeout", 75],
+    ["stuckMovementDistance", 20],
+    ["stuckDistanceImprovement", 10],
+    ["stuckMinimumTargetDistance", 100],
+    ["stuckEnemyExclusionRadius", 125],
+    ["targetMoveThreshold", 35],
+    ["cqbRadius", 75],
+    ["ignoreAircraft", true],
+    ["maxDesiredInfantry", -1],
+    ["hardInfantryCap", 450],
+    ["maxActiveVehicles", 20],
+    ["maxManagedInfantryGroups", 48],
+    ["maxManagedVehicleGroups", 24],
+    ["maxManagedGroups", 72],
+    ["infantryMinimumServerFPS", 15],
+    ["vehicleMinimumServerFPS", 15],
+    ["estimatedInfantryPerGroup", 12],
+    ["waveScript", "TMC_AttackWave_CloneWars.sqf"],
+    ["minSpawnRadius", 500],
+    ["maxSpawnRadius", 850],
+    ["debugMode", "NONE"]
 ];
 
 private _config = createHashMap;
-{ _config set [_x,_defaults get _x] } forEach keys _defaults;
-{ _config set [_x,_overrides get _x] } forEach keys _overrides;
+{ _config set [_x, _defaults get _x] } forEach keys _defaults;
+{ _config set [_x, _overrides get _x] } forEach keys _overrides;
+
+private _centerPos = _center call CBA_fnc_getPos;
+if ((count _centerPos) < 2) exitWith {
+    diag_log "[TMC v5 Director] START rejected because the center reference was invalid.";
+};
+
+private _existingManagedGroups = allGroups select {
+    _x getVariable ["TMC_attackWaveManaged", false]
+    && { units _x findIf { alive _x } >= 0 }
+};
+
+private _existingInfantryGroups = _existingManagedGroups select {
+    toUpper (_x getVariable ["TMC_attackWaveKind", "INFANTRY"]) isEqualTo "INFANTRY"
+};
+
+private _existingVehicleGroups = _existingManagedGroups select {
+    toUpper (_x getVariable ["TMC_attackWaveKind", ""]) isEqualTo "VEHICLE"
+};
+
+private _existingManagedVehicles = vehicles select {
+    alive _x
+    && { _x getVariable ["TMC_attackWaveVehicle", false] }
+    && { crew _x findIf { alive _x } >= 0 }
+};
+
+private _knownAircraft = vehicles select {
+    alive _x && { _x isKindOf "Air" }
+};
 
 private _now = diag_tickTime;
 private _state = createHashMapFromArray [
-    ["running",true],
-    ["paused",false],
-    ["center",_center],
-    ["config",_config],
-    ["pfhHandle",-1],
-    ["infantryHandles",[]],
-    ["vehicleHandles",[]],
-    ["packageNumber",0],
-    ["nextInfantryCheck",_now + (_config get "initialDelay")],
-    ["nextVehicleCheck",_now + (_config get "initialDelay") + (_config get "vehicleEvaluationOffset")],
-    ["nextBehaviorCheck",_now + (_config get "initialDelay") + 5],
-    ["snapshot",createHashMap]
+    ["running", true],
+    ["paused", false],
+    ["center", _center],
+    ["config", _config],
+    ["pfhHandle", -1],
+    ["entityCreatedEH", -1],
+    ["infantryHandles", []],
+    ["vehicleHandles", []],
+    ["infantryGroups", _existingInfantryGroups],
+    ["vehicleGroups", _existingVehicleGroups],
+    ["managedVehicles", _existingManagedVehicles],
+    ["knownAircraft", _knownAircraft],
+    ["packageNumber", 0],
+    ["retaskedTotal", 0],
+    ["stuckTotal", 0],
+    ["nextInfantryCheck", _now + (_config get "initialDelay")],
+    ["nextVehicleCheck", _now + (_config get "initialDelay") + (_config get "vehicleEvaluationOffset")],
+    ["nextBehaviorCheck", _now + (_config get "initialDelay") + 5],
+    ["nextStatusLog", _now + (_config get "statusLogInterval")],
+    ["snapshot", createHashMap]
 ];
-missionNamespace setVariable [_stateName,_state];
+
+missionNamespace setVariable [_stateName, _state];
+
+if (_config get "ignoreAircraft") then {
+    {
+        private _group = _x;
+        {
+            _group ignoreTarget _x;
+        } forEach _knownAircraft;
+    } forEach _existingInfantryGroups;
+};
+
+private _entityCreatedEH = addMissionEventHandler ["EntityCreated", {
+    params ["_entity"];
+
+    if (
+        !isServer
+        || { isNull _entity }
+        || { !(_entity isKindOf "Air") }
+    ) exitWith {};
+
+    private _stateName = "TMC_ContinuousDirector_State";
+    private _state = missionNamespace getVariable [_stateName, createHashMap];
+
+    if (
+        (count _state) isEqualTo 0
+        || { !(_state getOrDefault ["running", false]) }
+    ) exitWith {};
+
+    private _config = _state getOrDefault ["config", createHashMap];
+    if !(_config getOrDefault ["ignoreAircraft", true]) exitWith {};
+
+    private _knownAircraft = _state getOrDefault ["knownAircraft", []];
+    _knownAircraft pushBackUnique _entity;
+    _state set ["knownAircraft", _knownAircraft];
+
+    {
+        if (!isNull _x && { units _x findIf { alive _x } >= 0 }) then {
+            _x ignoreTarget _entity;
+        };
+    } forEach (_state getOrDefault ["infantryGroups", []]);
+
+    missionNamespace setVariable [_stateName, _state];
+}];
+
+_state set ["entityCreatedEH", _entityCreatedEH];
+missionNamespace setVariable [_stateName, _state];
 
 private _fnc_evaluate = {
-    params ["_args","_pfhHandle"];
+    params ["_args", "_pfhHandle"];
     _args params ["_stateName"];
 
-    private _state = missionNamespace getVariable [_stateName,createHashMap];
-    if ((count _state) isEqualTo 0) exitWith { [_pfhHandle] call CBA_fnc_removePerFrameHandler };
-    if !(_state getOrDefault ["running",false]) exitWith { [_pfhHandle] call CBA_fnc_removePerFrameHandler };
-    if (_state getOrDefault ["paused",false]) exitWith {};
+    private _state = missionNamespace getVariable [_stateName, createHashMap];
+
+    if ((count _state) isEqualTo 0) exitWith {
+        [_pfhHandle] call CBA_fnc_removePerFrameHandler;
+    };
+
+    if !(_state getOrDefault ["running", false]) exitWith {
+        [_pfhHandle] call CBA_fnc_removePerFrameHandler;
+    };
+
+    if (_state getOrDefault ["paused", false]) exitWith {};
 
     private _config = _state get "config";
+    private _now = diag_tickTime;
+    private _debugMode = toUpper (_config getOrDefault ["debugMode", "NONE"]);
+
+    private _infantryDue = _now >= (_state get "nextInfantryCheck");
+    private _vehicleDue = _now >= (_state get "nextVehicleCheck");
+    private _behaviorDue = _now >= (_state get "nextBehaviorCheck");
+    private _statusDue = _debugMode in ["LOG", "MARKERS"]
+        && { _now >= (_state get "nextStatusLog") };
+
+    if !(_infantryDue || _vehicleDue || _behaviorDue || _statusDue) exitWith {};
+
+    if (_infantryDue) then {
+        _state set [
+            "nextInfantryCheck",
+            _now + (_config get "infantryEvaluationInterval")
+        ];
+    };
+
+    if (_vehicleDue) then {
+        _state set [
+            "nextVehicleCheck",
+            _now + (_config get "vehicleEvaluationInterval")
+        ];
+    };
+
+    if (_behaviorDue) then {
+        _state set [
+            "nextBehaviorCheck",
+            _now + (_config get "behaviorEvaluationInterval")
+        ];
+    };
+
+    if (_statusDue) then {
+        _state set [
+            "nextStatusLog",
+            _now + (_config get "statusLogInterval")
+        ];
+    };
+
+    private _infantryHandles = (_state getOrDefault ["infantryHandles", []]) select {
+        !scriptDone _x
+    };
+    private _vehicleHandles = (_state getOrDefault ["vehicleHandles", []]) select {
+        !scriptDone _x
+    };
+
+    private _infantryGroups = (_state getOrDefault ["infantryGroups", []]) select {
+        !isNull _x && { units _x findIf { alive _x } >= 0 }
+    };
+    private _vehicleGroups = (_state getOrDefault ["vehicleGroups", []]) select {
+        !isNull _x && { units _x findIf { alive _x } >= 0 }
+    };
+    private _managedVehicles = (_state getOrDefault ["managedVehicles", []]) select {
+        !isNull _x
+        && { alive _x }
+        && { crew _x findIf { alive _x } >= 0 }
+    };
+    private _knownAircraft = (_state getOrDefault ["knownAircraft", []]) select {
+        !isNull _x && { alive _x }
+    };
+
+    _state set ["infantryHandles", _infantryHandles];
+    _state set ["vehicleHandles", _vehicleHandles];
+    _state set ["infantryGroups", _infantryGroups];
+    _state set ["vehicleGroups", _vehicleGroups];
+    _state set ["managedVehicles", _managedVehicles];
+    _state set ["knownAircraft", _knownAircraft];
+
     private _center = _state get "center";
     private _centerPos = _center call CBA_fnc_getPos;
+    if ((count _centerPos) < 2) exitWith {
+        diag_log "[TMC v5 Director] Center reference became invalid. Director stopped.";
+        _state set ["running", false];
+        missionNamespace setVariable [_stateName, _state];
+        [_pfhHandle] call CBA_fnc_removePerFrameHandler;
+    };
+
+    _centerPos resize 3;
+    _centerPos set [2, 0];
+
+    private _snapshotPrevious = _state getOrDefault ["snapshot", createHashMap];
+    private _scalingCount = _snapshotPrevious getOrDefault ["BLUFOR", 0];
     private _scalingSide = _config get "scalingSide";
     private _enemySide = _config get "enemySide";
-    private _mode = toUpper (_config get "scalingMode");
 
-    private _sideUnits = allUnits select {
-        alive _x && {side group _x isEqualTo _scalingSide}
-    };
-
-    private _scalingUnits = switch (_mode) do {
-        case "SIDE": {_sideUnits};
-        case "RADIUS": {_sideUnits select {_x distance2D _centerPos <= (_config get "scalingRadius")}};
-        default {
-            if ((_center isEqualType objNull && {!isNull _center}) || {_center isEqualType "" && {markerShape _center != ""}}) then {
-                _sideUnits select {_x inArea _center}
-            } else {
-                _sideUnits select {_x distance2D _centerPos <= (_config get "scalingRadius")}
-            }
+    if (_infantryDue || _vehicleDue || _statusDue) then {
+        private _sideUnits = allUnits select {
+            alive _x && { side group _x isEqualTo _scalingSide }
         };
-    };
-    private _scalingCount = count _scalingUnits;
 
-    private _infantryHandles = (_state getOrDefault ["infantryHandles",[]]) select {!(scriptDone _x)};
-    private _vehicleHandles = (_state getOrDefault ["vehicleHandles",[]]) select {!(scriptDone _x)};
-    _state set ["infantryHandles",_infantryHandles];
-    _state set ["vehicleHandles",_vehicleHandles];
+        private _scalingMode = toUpper (_config get "scalingMode");
+        private _scalingUnits = switch (_scalingMode) do {
+            case "SIDE": {
+                _sideUnits
+            };
 
-    private _managedGroups = allGroups select {
-        _x getVariable ["TMC_attackWaveManaged",false]
-        && {units _x findIf {alive _x} >= 0}
-    };
-    private _infantryGroups = _managedGroups select {
-        toUpper (_x getVariable ["TMC_attackWaveKind","INFANTRY"]) isEqualTo "INFANTRY"
-    };
-    private _vehicleGroups = _managedGroups select {
-        toUpper (_x getVariable ["TMC_attackWaveKind",""]) isEqualTo "VEHICLE"
+            case "RADIUS": {
+                _sideUnits select {
+                    _x distance2D _centerPos <= (_config get "scalingRadius")
+                }
+            };
+
+            default {
+                if (
+                    (_center isEqualType objNull && { !isNull _center })
+                    || { _center isEqualType "" && { markerShape _center != "" } }
+                ) then {
+                    _sideUnits select { _x inArea _center }
+                } else {
+                    _sideUnits select {
+                        _x distance2D _centerPos <= (_config get "scalingRadius")
+                    }
+                }
+            };
+        };
+
+        _scalingCount = count _scalingUnits;
     };
 
     private _infantryCount = 0;
     {
-        _infantryCount = _infantryCount + ({alive _x && {side group _x isEqualTo _enemySide}} count units _x);
+        _infantryCount = _infantryCount + ({
+            alive _x && { side group _x isEqualTo _enemySide }
+        } count units _x);
     } forEach _infantryGroups;
 
-    private _managedVehicles = vehicles select {
-        alive _x
-        && {_x getVariable ["TMC_attackWaveVehicle",false]}
-        && {crew _x findIf {alive _x} >= 0}
+    private _desiredInfantry = round (
+        _scalingCount * (_config get "enemyRatio")
+    );
+
+    private _maxDesired = round (_config get "maxDesiredInfantry");
+    if (_maxDesired > 0) then {
+        _desiredInfantry = _desiredInfantry min _maxDesired;
     };
 
-    private _desiredInfantry = round (_scalingCount * (_config get "enemyRatio"));
-    private _maxDesired = round (_config get "maxDesiredInfantry");
-    if (_maxDesired > 0) then {_desiredInfantry = _desiredInfantry min _maxDesired};
     _desiredInfantry = _desiredInfantry min round (_config get "hardInfantryCap");
 
     private _desiredVehicles = if (_scalingCount > 0) then {
-        (ceil (_scalingCount / ((_config get "scalingUnitsPerVehicle") max 1))) max 1
-    } else {0};
+        (ceil (
+            _scalingCount
+            / ((_config get "scalingUnitsPerVehicle") max 1)
+        )) max 1
+    } else {
+        0
+    };
+
     _desiredVehicles = _desiredVehicles min round (_config get "maxActiveVehicles");
 
-    private _effectiveInfantry = _infantryCount + (count _infantryHandles * round (_config get "estimatedInfantryPerGroup"));
+    private _effectiveInfantry = _infantryCount
+        + (count _infantryHandles * round (_config get "estimatedInfantryPerGroup"));
     private _effectiveVehicles = count _managedVehicles + count _vehicleHandles;
     private _infantryDeficit = (_desiredInfantry - _effectiveInfantry) max 0;
     private _vehicleDeficit = (_desiredVehicles - _effectiveVehicles) max 0;
 
-    private _now = diag_tickTime;
-    private _infantryDue = _now >= (_state get "nextInfantryCheck");
-    private _vehicleDue = _now >= (_state get "nextVehicleCheck");
-    private _behaviorDue = _now >= (_state get "nextBehaviorCheck");
+    private _retaskedThisCheck = 0;
+    private _stuckThisCheck = 0;
 
-    if (_infantryDue) then {
-        _state set ["nextInfantryCheck",_now + (_config get "infantryEvaluationInterval")];
-    };
-    if (_vehicleDue) then {
-        _state set ["nextVehicleCheck",_now + (_config get "vehicleEvaluationInterval")];
-    };
-    if (_behaviorDue) then {
-        _state set ["nextBehaviorCheck",_now + (_config get "behaviorEvaluationInterval")];
-    };
-
-    private _retaskedGroups = 0;
-    private _stuckGroups = 0;
-
-    if (_behaviorDue && {!(_infantryGroups isEqualTo [])}) then {
-        private _aircraft = vehicles select { alive _x && {_x isKindOf "Air"} };
+    if (_behaviorDue && { !(_infantryGroups isEqualTo []) }) then {
         private _groundPlayers = ([] call CBA_fnc_players) select {
             alive _x
-            && {side group _x isEqualTo _scalingSide}
-            && {!((vehicle _x) isKindOf "Air")}
+            && { side group _x isEqualTo _scalingSide }
+            && { !((vehicle _x) isKindOf "Air") }
         };
-        private _groundLeaders = _groundPlayers select { leader group _x isEqualTo _x };
-        private _targetPool = if (_groundLeaders isEqualTo []) then {_groundPlayers} else {_groundLeaders};
+
+        private _groundLeaders = _groundPlayers select {
+            leader group _x isEqualTo _x
+        };
+
+        private _targetPool = if (_groundLeaders isEqualTo []) then {
+            _groundPlayers
+        } else {
+            _groundLeaders
+        };
+
+        private _hasLAMBS_CQB = !isNil "lambs_wp_fnc_taskCQB";
 
         {
             private _group = _x;
             private _leader = leader _group;
 
             if (!isNull _leader) then {
-                _group setBehaviourStrong "AWARE";
-                _group setCombatMode "YELLOW";
-                _group setSpeedMode "FULL";
-                _group enableAttack false;
-                _group allowFleeing 0;
-
-                {
-                    _group ignoreTarget _x;
-                } forEach _aircraft;
-
                 private _target = objNull;
+
                 if !(_targetPool isEqualTo []) then {
                     _target = _targetPool select 0;
                     private _bestDistance = _leader distance2D _target;
+
                     {
                         private _distance = _leader distance2D _x;
                         if (_distance < _bestDistance) then {
@@ -224,65 +427,194 @@ private _fnc_evaluate = {
                     } forEach _targetPool;
                 };
 
-                private _targetPos = if (isNull _target) then {+_centerPos} else {getPosATL _target};
-                _targetPos resize 3;
-                _targetPos set [2,0];
-
-                private _waypoint = _group getVariable ["TMC_attackWaypoint",[]];
-                if !(_waypoint isEqualTo []) then {
-                    private _oldTargetPos = _group getVariable ["TMC_attackTargetPosition",_targetPos];
-                    if (_oldTargetPos distance2D _targetPos >= (_config get "targetMoveThreshold")) then {
-                        _waypoint setWaypointPosition [_targetPos,-1];
-                        _group setCurrentWaypoint _waypoint;
-                        _group move _targetPos;
-                        _group setVariable ["TMC_attackTargetPosition",_targetPos];
-                        _group setVariable ["TMC_attackTarget",_target];
-                        _group setVariable ["TMC_lastRetaskTime",_now];
-                        _retaskedGroups = _retaskedGroups + 1;
-                    };
+                private _targetPos = if (isNull _target) then {
+                    +_centerPos
+                } else {
+                    getPosATL _target
                 };
 
-                private _lastPosition = _group getVariable ["TMC_lastLeaderPosition",getPosATL _leader];
-                private _lastProgress = _group getVariable ["TMC_lastProgressTime",_now];
+                _targetPos resize 3;
+                _targetPos set [2, 0];
 
-                if (_leader distance2D _lastPosition >= (_config get "stuckMovementDistance")) then {
-                    _group setVariable ["TMC_lastLeaderPosition",getPosATL _leader];
-                    _group setVariable ["TMC_lastProgressTime",_now];
-                } else {
-                    if (_now - _lastProgress >= (_config get "stuckTimeout")) then {
-                        _stuckGroups = _stuckGroups + 1;
-                        if !(_waypoint isEqualTo []) then {
-                            _waypoint setWaypointPosition [_targetPos,-1];
-                            _group setCurrentWaypoint _waypoint;
-                        };
-                        {
-                            if (alive _x) then {
-                                _x forceSpeed -1;
-                                _x doFollow _leader;
-                            };
-                        } forEach units _group;
+                private _lambsTask = _leader getVariable [
+                    "lambs_main_currentTask",
+                    ""
+                ];
+                private _activeCQB = (_lambsTask find "Clearing rooms") >= 0
+                    || { (_lambsTask find "Rush enemy") >= 0 };
+
+                private _nearestEnemy = _leader findNearestEnemy (getPosATL _leader);
+                private _enemyNearby = !isNull _nearestEnemy
+                    && {
+                        _leader distance2D _nearestEnemy
+                        <= (_config get "stuckEnemyExclusionRadius")
+                    };
+
+                private _waypoint = _group getVariable ["TMC_attackWaypoint", []];
+                private _hasWaypoint = !(_waypoint isEqualTo [])
+                    && { count waypoints _group > 0 };
+
+                if (!_hasWaypoint) then {
+                    _waypoint = _group addWaypoint [_targetPos, -1];
+                    _waypoint setWaypointType ([
+                        "SAD",
+                        "lambs_danger_CQB"
+                    ] select _hasLAMBS_CQB);
+                    _waypoint setWaypointBehaviour "AWARE";
+                    _waypoint setWaypointCombatMode "YELLOW";
+                    _waypoint setWaypointSpeed "FULL";
+                    _waypoint setWaypointCompletionRadius (
+                        (_config get "cqbRadius") max 25
+                    );
+                    _group setCurrentWaypoint _waypoint;
+                    _group setVariable ["TMC_attackWaypoint", _waypoint];
+                    _retaskedThisCheck = _retaskedThisCheck + 1;
+                };
+
+                private _oldTarget = _group getVariable [
+                    "TMC_attackTarget",
+                    objNull
+                ];
+                private _oldTargetPos = _group getVariable [
+                    "TMC_attackTargetPosition",
+                    _targetPos
+                ];
+
+                private _targetChanged = !(_oldTarget isEqualTo _target);
+                private _targetMoved = _oldTargetPos distance2D _targetPos
+                    >= (_config get "targetMoveThreshold");
+
+                if (_targetChanged || _targetMoved) then {
+                    _waypoint setWaypointPosition [_targetPos, -1];
+                    _group setCurrentWaypoint _waypoint;
+
+                    if (!_enemyNearby && { !_activeCQB }) then {
                         _group move _targetPos;
-                        _group setVariable ["TMC_lastLeaderPosition",getPosATL _leader];
-                        _group setVariable ["TMC_lastProgressTime",_now];
-                        _group setVariable ["TMC_lastRetaskTime",_now];
+                    };
+
+                    _group setVariable ["TMC_attackTarget", _target];
+                    _group setVariable ["TMC_attackTargetPosition", _targetPos];
+                    _retaskedThisCheck = _retaskedThisCheck + 1;
+                };
+
+                private _distanceToTarget = _leader distance2D _targetPos;
+                private _lastPosition = _group getVariable [
+                    "TMC_lastLeaderPosition",
+                    getPosATL _leader
+                ];
+                private _lastProgress = _group getVariable [
+                    "TMC_lastProgressTime",
+                    _now
+                ];
+                private _lastTargetDistance = _group getVariable [
+                    "TMC_lastTargetDistance",
+                    _distanceToTarget
+                ];
+
+                if (
+                    _enemyNearby
+                    || { _activeCQB }
+                    || {
+                        _distanceToTarget
+                        <= (_config get "stuckMinimumTargetDistance")
+                    }
+                ) then {
+                    _group setVariable [
+                        "TMC_lastLeaderPosition",
+                        getPosATL _leader
+                    ];
+                    _group setVariable ["TMC_lastProgressTime", _now];
+                    _group setVariable [
+                        "TMC_lastTargetDistance",
+                        _distanceToTarget
+                    ];
+                } else {
+                    private _movedEnough = _leader distance2D _lastPosition
+                        >= (_config get "stuckMovementDistance");
+                    private _closedDistance = _lastTargetDistance - _distanceToTarget
+                        >= (_config get "stuckDistanceImprovement");
+
+                    if (_movedEnough || _closedDistance) then {
+                        _group setVariable [
+                            "TMC_lastLeaderPosition",
+                            getPosATL _leader
+                        ];
+                        _group setVariable ["TMC_lastProgressTime", _now];
+                        _group setVariable [
+                            "TMC_lastTargetDistance",
+                            _distanceToTarget
+                        ];
+                    } else {
+                        if (
+                            _now - _lastProgress
+                            >= (_config get "stuckTimeout")
+                        ) then {
+                            _stuckThisCheck = _stuckThisCheck + 1;
+
+                            _waypoint setWaypointPosition [_targetPos, -1];
+                            _group setCurrentWaypoint _waypoint;
+
+                            {
+                                if (alive _x) then {
+                                    _x forceSpeed -1;
+                                    _x doFollow _leader;
+                                };
+                            } forEach units _group;
+
+                            _group move _targetPos;
+                            _group setVariable [
+                                "TMC_lastLeaderPosition",
+                                getPosATL _leader
+                            ];
+                            _group setVariable ["TMC_lastProgressTime", _now];
+                            _group setVariable [
+                                "TMC_lastTargetDistance",
+                                _distanceToTarget
+                            ];
+                        };
                     };
                 };
             };
         } forEach _infantryGroups;
     };
 
-    private _sharedUsed = count _managedGroups + count _infantryHandles + count _vehicleHandles;
-    private _canUseShared = _sharedUsed < round (_config get "maxManagedGroups");
+    private _retaskedTotal = (_state getOrDefault ["retaskedTotal", 0])
+        + _retaskedThisCheck;
+    private _stuckTotal = (_state getOrDefault ["stuckTotal", 0])
+        + _stuckThisCheck;
+
+    _state set ["retaskedTotal", _retaskedTotal];
+    _state set ["stuckTotal", _stuckTotal];
+
+    private _usedSharedSlots = count _infantryGroups
+        + count _vehicleGroups
+        + count _infantryHandles
+        + count _vehicleHandles;
+    private _availableSharedSlots = (
+        round (_config get "maxManagedGroups") - _usedSharedSlots
+    ) max 0;
+    private _availableInfantrySlots = (
+        round (_config get "maxManagedInfantryGroups")
+        - count _infantryGroups
+        - count _infantryHandles
+    ) max 0;
+    private _availableVehicleSlots = (
+        round (_config get "maxManagedVehicleGroups")
+        - count _vehicleGroups
+        - count _vehicleHandles
+    ) max 0;
+
+    private _fps = diag_fps;
     private _sentInfantry = false;
     private _sentVehicle = false;
 
     if (
         _infantryDue
-        && {_scalingCount >= round (_config get "minimumScalingUnits")}
-        && {_infantryDeficit > 0}
-        && {_canUseShared}
-        && {count _infantryGroups + count _infantryHandles < round (_config get "maxManagedInfantryGroups")}
-        && {diag_fps >= (_config get "infantryMinimumServerFPS")}
+        && { _scalingCount >= round (_config get "minimumScalingUnits") }
+        && { _infantryDeficit > 0 }
+        && { _availableSharedSlots > 0 }
+        && { _availableInfantrySlots > 0 }
+        && { _fps >= (_config get "infantryMinimumServerFPS") }
     ) then {
         private _id = (_state get "packageNumber") + 1;
         private _handle = [
@@ -291,22 +623,35 @@ private _fnc_evaluate = {
             _config get "maxSpawnRadius",
             1,
             0,
-            _config get "debugMode",
-            _id
+            _debugMode,
+            _id,
+            _scalingSide,
+            _config get "cqbRadius"
         ] execVM (_config get "waveScript");
+
         _infantryHandles pushBack _handle;
-        _state set ["infantryHandles",_infantryHandles];
-        _state set ["packageNumber",_id];
+        _state set ["infantryHandles", _infantryHandles];
+        _state set ["packageNumber", _id];
+        _availableSharedSlots = _availableSharedSlots - 1;
+        _availableInfantrySlots = _availableInfantrySlots - 1;
         _sentInfantry = true;
+
+        if (_debugMode in ["LOG", "MARKERS"]) then {
+            diag_log format [
+                "[TMC v5 Director] Requested infantry package %1. Deficit %2.",
+                _id,
+                _infantryDeficit
+            ];
+        };
     };
 
     if (
         _vehicleDue
-        && {_scalingCount >= round (_config get "minimumScalingUnits")}
-        && {_vehicleDeficit > 0}
-        && {_canUseShared}
-        && {count _vehicleGroups + count _vehicleHandles < round (_config get "maxManagedVehicleGroups")}
-        && {diag_fps >= (_config get "vehicleMinimumServerFPS")}
+        && { _scalingCount >= round (_config get "minimumScalingUnits") }
+        && { _vehicleDeficit > 0 }
+        && { _availableSharedSlots > 0 }
+        && { _availableVehicleSlots > 0 }
+        && { _fps >= (_config get "vehicleMinimumServerFPS") }
     ) then {
         private _id = (_state get "packageNumber") + 1;
         private _handle = [
@@ -315,42 +660,80 @@ private _fnc_evaluate = {
             _config get "maxSpawnRadius",
             0,
             1,
-            _config get "debugMode",
-            _id
+            _debugMode,
+            _id,
+            _scalingSide,
+            _config get "cqbRadius"
         ] execVM (_config get "waveScript");
+
         _vehicleHandles pushBack _handle;
-        _state set ["vehicleHandles",_vehicleHandles];
-        _state set ["packageNumber",_id];
+        _state set ["vehicleHandles", _vehicleHandles];
+        _state set ["packageNumber", _id];
+        _availableSharedSlots = _availableSharedSlots - 1;
+        _availableVehicleSlots = _availableVehicleSlots - 1;
         _sentVehicle = true;
+
+        if (_debugMode in ["LOG", "MARKERS"]) then {
+            diag_log format [
+                "[TMC v5 Director] Requested vehicle package %1. Deficit %2.",
+                _id,
+                _vehicleDeficit
+            ];
+        };
     };
 
     private _snapshot = createHashMapFromArray [
-        ["BLUFOR",_scalingCount],
-        ["infantry",_infantryCount],
-        ["desiredInfantry",_desiredInfantry],
-        ["infantryDeficit",_infantryDeficit],
-        ["vehicles",count _managedVehicles],
-        ["desiredVehicles",_desiredVehicles],
-        ["vehicleDeficit",_vehicleDeficit],
-        ["infantryGroups",count _infantryGroups],
-        ["vehicleGroups",count _vehicleGroups],
-        ["retaskedGroups",_retaskedGroups],
-        ["stuckGroups",_stuckGroups],
-        ["sentInfantry",_sentInfantry],
-        ["sentVehicle",_sentVehicle],
-        ["fps",diag_fps]
+        ["running", true],
+        ["paused", false],
+        ["BLUFOR", _scalingCount],
+        ["infantry", _infantryCount],
+        ["desiredInfantry", _desiredInfantry],
+        ["effectiveInfantry", _effectiveInfantry],
+        ["infantryDeficit", _infantryDeficit],
+        ["vehicles", count _managedVehicles],
+        ["desiredVehicles", _desiredVehicles],
+        ["effectiveVehicles", _effectiveVehicles],
+        ["vehicleDeficit", _vehicleDeficit],
+        ["infantryGroups", count _infantryGroups],
+        ["vehicleGroups", count _vehicleGroups],
+        ["pendingInfantryPackages", count _infantryHandles],
+        ["pendingVehiclePackages", count _vehicleHandles],
+        ["retaskedThisCheck", _retaskedThisCheck],
+        ["stuckThisCheck", _stuckThisCheck],
+        ["retaskedTotal", _retaskedTotal],
+        ["stuckTotal", _stuckTotal],
+        ["sentInfantry", _sentInfantry],
+        ["sentVehicle", _sentVehicle],
+        ["fps", _fps]
     ];
-    _state set ["snapshot",_snapshot];
-    missionNamespace setVariable [_stateName,_state];
 
-    if ((_config get "debugMode") in ["LOG","MARKERS"]) then {
-        diag_log format ["[TMC v5 Director] %1",_snapshot];
+    _state set ["snapshot", _snapshot];
+    missionNamespace setVariable [_stateName, _state];
+
+    if (
+        _debugMode in ["LOG", "MARKERS"]
+        && { _retaskedThisCheck > 0 || { _stuckThisCheck > 0 } }
+    ) then {
+        diag_log format [
+            "[TMC v5 Director] Behavior check retasked %1 groups and recovered %2 stuck groups.",
+            _retaskedThisCheck,
+            _stuckThisCheck
+        ];
+    };
+
+    if (_statusDue) then {
+        diag_log format ["[TMC v5 Director] %1", _snapshot];
     };
 };
 
-private _pfh = [_fnc_evaluate,0.5,[_stateName]] call CBA_fnc_addPerFrameHandler;
-_state set ["pfhHandle",_pfh];
-missionNamespace setVariable [_stateName,_state];
+private _pfhHandle = [
+    _fnc_evaluate,
+    0.5,
+    [_stateName]
+] call CBA_fnc_addPerFrameHandler;
+
+_state set ["pfhHandle", _pfhHandle];
+missionNamespace setVariable [_stateName, _state];
 
 diag_log format [
     "[TMC v5 Director] Started. Infantry %1:1 every %2s. Vehicles 1:%3 every %4s with %5s offset. Behavior checks every %6s.",

--- a/TMC_ContinuousDirector_v5/TMC_ContinuousDirector.sqf
+++ b/TMC_ContinuousDirector_v5/TMC_ContinuousDirector.sqf
@@ -1,0 +1,257 @@
+if (!isServer) exitWith {};
+
+params [
+    ["_mode","START",[""]],
+    ["_center",objNull],
+    ["_overrides",createHashMap]
+];
+
+_mode = toUpper _mode;
+private _stateName = "TMC_ContinuousDirector_State";
+
+if (_mode in ["STOP","PAUSE","RESUME","STATUS"]) exitWith {
+    private _state = missionNamespace getVariable [_stateName,createHashMap];
+    if ((count _state) isEqualTo 0) exitWith {};
+    switch (_mode) do {
+        case "STOP": {
+            _state set ["running",false];
+            private _handle = _state getOrDefault ["pfhHandle",-1];
+            if (_handle >= 0) then { [_handle] call CBA_fnc_removePerFrameHandler };
+            missionNamespace setVariable [_stateName,_state];
+        };
+        case "PAUSE": {
+            _state set ["paused",true];
+            missionNamespace setVariable [_stateName,_state];
+        };
+        case "RESUME": {
+            _state set ["paused",false];
+            missionNamespace setVariable [_stateName,_state];
+        };
+        case "STATUS": {
+            diag_log format ["[TMC v5 Director] %1",_state getOrDefault ["snapshot",createHashMap]];
+        };
+    };
+};
+
+if !(_mode isEqualTo "START") exitWith {};
+if !(_overrides isEqualType createHashMap) exitWith {};
+
+private _old = missionNamespace getVariable [_stateName,createHashMap];
+if ((count _old) > 0 && {_old getOrDefault ["running",false]}) exitWith {
+    diag_log "[TMC v5 Director] START ignored because the director is already running.";
+};
+
+private _defaults = createHashMapFromArray [
+    ["scalingMode","AREA"],
+    ["scalingSide",west],
+    ["scalingRadius",300],
+    ["minimumScalingUnits",1],
+    ["enemySide",east],
+    ["enemyRatio",3],
+    ["scalingUnitsPerVehicle",10],
+    ["initialDelay",1],
+    ["infantryEvaluationInterval",5],
+    ["vehicleEvaluationInterval",10],
+    ["vehicleEvaluationOffset",2.5],
+    ["maxDesiredInfantry",-1],
+    ["hardInfantryCap",450],
+    ["maxActiveVehicles",20],
+    ["maxManagedInfantryGroups",48],
+    ["maxManagedVehicleGroups",24],
+    ["maxManagedGroups",72],
+    ["infantryMinimumServerFPS",15],
+    ["vehicleMinimumServerFPS",15],
+    ["estimatedInfantryPerGroup",12],
+    ["waveScript","TMC_AttackWave_CloneWars.sqf"],
+    ["minSpawnRadius",500],
+    ["maxSpawnRadius",850],
+    ["debugMode","LOG"]
+];
+
+private _config = createHashMap;
+{ _config set [_x,_defaults get _x] } forEach keys _defaults;
+{ _config set [_x,_overrides get _x] } forEach keys _overrides;
+
+private _now = diag_tickTime;
+private _state = createHashMapFromArray [
+    ["running",true],
+    ["paused",false],
+    ["center",_center],
+    ["config",_config],
+    ["pfhHandle",-1],
+    ["infantryHandles",[]],
+    ["vehicleHandles",[]],
+    ["packageNumber",0],
+    ["nextInfantryCheck",_now + (_config get "initialDelay")],
+    ["nextVehicleCheck",_now + (_config get "initialDelay") + (_config get "vehicleEvaluationOffset")],
+    ["snapshot",createHashMap]
+];
+missionNamespace setVariable [_stateName,_state];
+
+private _fnc_evaluate = {
+    params ["_args","_pfhHandle"];
+    _args params ["_stateName"];
+    private _state = missionNamespace getVariable [_stateName,createHashMap];
+    if ((count _state) isEqualTo 0) exitWith { [_pfhHandle] call CBA_fnc_removePerFrameHandler };
+    if !(_state getOrDefault ["running",false]) exitWith { [_pfhHandle] call CBA_fnc_removePerFrameHandler };
+    if (_state getOrDefault ["paused",false]) exitWith {};
+
+    private _config = _state get "config";
+    private _center = _state get "center";
+    private _centerPos = _center call CBA_fnc_getPos;
+    private _scalingSide = _config get "scalingSide";
+    private _enemySide = _config get "enemySide";
+    private _mode = toUpper (_config get "scalingMode");
+    private _sideUnits = allUnits select {
+        alive _x && {side group _x isEqualTo _scalingSide}
+    };
+    private _scalingUnits = switch (_mode) do {
+        case "SIDE": {_sideUnits};
+        case "RADIUS": {_sideUnits select {_x distance2D _centerPos <= (_config get "scalingRadius")}};
+        default {
+            if ((_center isEqualType objNull && {!isNull _center}) || {_center isEqualType "" && {markerShape _center != ""}}) then {
+                _sideUnits select {_x inArea _center}
+            } else {
+                _sideUnits select {_x distance2D _centerPos <= (_config get "scalingRadius")}
+            }
+        };
+    };
+    private _scalingCount = count _scalingUnits;
+
+    private _infantryHandles = (_state getOrDefault ["infantryHandles",[]]) select {!(scriptDone _x)};
+    private _vehicleHandles = (_state getOrDefault ["vehicleHandles",[]]) select {!(scriptDone _x)};
+    _state set ["infantryHandles",_infantryHandles];
+    _state set ["vehicleHandles",_vehicleHandles];
+
+    private _managedGroups = allGroups select {
+        _x getVariable ["TMC_attackWaveManaged",false]
+        && {units _x findIf {alive _x} >= 0}
+    };
+    private _infantryGroups = _managedGroups select {
+        toUpper (_x getVariable ["TMC_attackWaveKind","INFANTRY"]) isEqualTo "INFANTRY"
+    };
+    private _vehicleGroups = _managedGroups select {
+        toUpper (_x getVariable ["TMC_attackWaveKind",""]) isEqualTo "VEHICLE"
+    };
+    private _infantryCount = 0;
+    {
+        _infantryCount = _infantryCount + ({alive _x && {side group _x isEqualTo _enemySide}} count units _x);
+    } forEach _infantryGroups;
+    private _managedVehicles = vehicles select {
+        alive _x
+        && {_x getVariable ["TMC_attackWaveVehicle",false]}
+        && {crew _x findIf {alive _x} >= 0}
+    };
+
+    private _desiredInfantry = round (_scalingCount * (_config get "enemyRatio"));
+    private _maxDesired = round (_config get "maxDesiredInfantry");
+    if (_maxDesired > 0) then {_desiredInfantry = _desiredInfantry min _maxDesired};
+    _desiredInfantry = _desiredInfantry min round (_config get "hardInfantryCap");
+
+    private _desiredVehicles = if (_scalingCount > 0) then {
+        (ceil (_scalingCount / ((_config get "scalingUnitsPerVehicle") max 1))) max 1
+    } else {0};
+    _desiredVehicles = _desiredVehicles min round (_config get "maxActiveVehicles");
+
+    private _effectiveInfantry = _infantryCount + (count _infantryHandles * round (_config get "estimatedInfantryPerGroup"));
+    private _effectiveVehicles = count _managedVehicles + count _vehicleHandles;
+    private _infantryDeficit = (_desiredInfantry - _effectiveInfantry) max 0;
+    private _vehicleDeficit = (_desiredVehicles - _effectiveVehicles) max 0;
+
+    private _now = diag_tickTime;
+    private _infantryDue = _now >= (_state get "nextInfantryCheck");
+    private _vehicleDue = _now >= (_state get "nextVehicleCheck");
+    if (_infantryDue) then {
+        _state set ["nextInfantryCheck",_now + (_config get "infantryEvaluationInterval")];
+    };
+    if (_vehicleDue) then {
+        _state set ["nextVehicleCheck",_now + (_config get "vehicleEvaluationInterval")];
+    };
+
+    private _sharedUsed = count _managedGroups + count _infantryHandles + count _vehicleHandles;
+    private _canUseShared = _sharedUsed < round (_config get "maxManagedGroups");
+    private _sentInfantry = false;
+    private _sentVehicle = false;
+
+    if (
+        _infantryDue
+        && {_scalingCount >= round (_config get "minimumScalingUnits")}
+        && {_infantryDeficit > 0}
+        && {_canUseShared}
+        && {count _infantryGroups + count _infantryHandles < round (_config get "maxManagedInfantryGroups")}
+        && {diag_fps >= (_config get "infantryMinimumServerFPS")}
+    ) then {
+        private _id = (_state get "packageNumber") + 1;
+        private _handle = [
+            _center,
+            _config get "minSpawnRadius",
+            _config get "maxSpawnRadius",
+            1,
+            0,
+            _config get "debugMode",
+            _id
+        ] execVM (_config get "waveScript");
+        _infantryHandles pushBack _handle;
+        _state set ["infantryHandles",_infantryHandles];
+        _state set ["packageNumber",_id];
+        _sentInfantry = true;
+    };
+
+    if (
+        _vehicleDue
+        && {_scalingCount >= round (_config get "minimumScalingUnits")}
+        && {_vehicleDeficit > 0}
+        && {_canUseShared}
+        && {count _vehicleGroups + count _vehicleHandles < round (_config get "maxManagedVehicleGroups")}
+        && {diag_fps >= (_config get "vehicleMinimumServerFPS")}
+    ) then {
+        private _id = (_state get "packageNumber") + 1;
+        private _handle = [
+            _center,
+            _config get "minSpawnRadius",
+            _config get "maxSpawnRadius",
+            0,
+            1,
+            _config get "debugMode",
+            _id
+        ] execVM (_config get "waveScript");
+        _vehicleHandles pushBack _handle;
+        _state set ["vehicleHandles",_vehicleHandles];
+        _state set ["packageNumber",_id];
+        _sentVehicle = true;
+    };
+
+    private _snapshot = createHashMapFromArray [
+        ["BLUFOR",_scalingCount],
+        ["infantry",_infantryCount],
+        ["desiredInfantry",_desiredInfantry],
+        ["infantryDeficit",_infantryDeficit],
+        ["vehicles",count _managedVehicles],
+        ["desiredVehicles",_desiredVehicles],
+        ["vehicleDeficit",_vehicleDeficit],
+        ["infantryGroups",count _infantryGroups],
+        ["vehicleGroups",count _vehicleGroups],
+        ["sentInfantry",_sentInfantry],
+        ["sentVehicle",_sentVehicle],
+        ["fps",diag_fps]
+    ];
+    _state set ["snapshot",_snapshot];
+    missionNamespace setVariable [_stateName,_state];
+
+    if ((_config get "debugMode") in ["LOG","MARKERS"]) then {
+        diag_log format ["[TMC v5 Director] %1",_snapshot];
+    };
+};
+
+private _pfh = [_fnc_evaluate,0.5,[_stateName]] call CBA_fnc_addPerFrameHandler;
+_state set ["pfhHandle",_pfh];
+missionNamespace setVariable [_stateName,_state];
+
+diag_log format [
+    "[TMC v5 Director] Started. Infantry %1:1 every %2s. Vehicles 1:%3 every %4s with %5s offset.",
+    _config get "enemyRatio",
+    _config get "infantryEvaluationInterval",
+    _config get "scalingUnitsPerVehicle",
+    _config get "vehicleEvaluationInterval",
+    _config get "vehicleEvaluationOffset"
+];

--- a/TMC_ContinuousDirector_v5/TMC_ContinuousDirector.sqf
+++ b/TMC_ContinuousDirector_v5/TMC_ContinuousDirector.sqf
@@ -51,14 +51,20 @@ if (_mode in ["STOP", "PAUSE", "RESUME", "STATUS"]) exitWith {
 
         case "PAUSE": {
             _state set ["paused", true];
+            private _snapshot = _state getOrDefault ["snapshot", createHashMap];
+            _snapshot set ["paused", true];
+            _state set ["snapshot", _snapshot];
             missionNamespace setVariable [_stateName, _state];
-            diag_log "[TMC v5 Director] Paused.";
+            diag_log "[TMC v5 Director] Paused by command.";
         };
 
         case "RESUME": {
             _state set ["paused", false];
+            private _snapshot = _state getOrDefault ["snapshot", createHashMap];
+            _snapshot set ["paused", false];
+            _state set ["snapshot", _snapshot];
             missionNamespace setVariable [_stateName, _state];
-            diag_log "[TMC v5 Director] Resumed.";
+            diag_log "[TMC v5 Director] Resumed by command.";
         };
 
         case "STATUS": {
@@ -108,6 +114,10 @@ private _defaults = createHashMapFromArray [
     ["targetMoveThreshold", 35],
     ["cqbRadius", 75],
     ["ignoreAircraft", true],
+    ["mergeEnabled", true],
+    ["mergeThreshold", 5],
+    ["mergeSearchRadius", 300],
+    ["maximumMergedGroupSize", 30],
     ["maxDesiredInfantry", -1],
     ["hardInfantryCap", 450],
     ["maxActiveVehicles", 20],
@@ -116,7 +126,7 @@ private _defaults = createHashMapFromArray [
     ["maxManagedGroups", 72],
     ["infantryMinimumServerFPS", 15],
     ["vehicleMinimumServerFPS", 15],
-    ["estimatedInfantryPerGroup", 12],
+    ["estimatedInfantryPerGroup", 20],
     ["waveScript", "TMC_AttackWave_CloneWars.sqf"],
     ["minSpawnRadius", 500],
     ["maxSpawnRadius", 850],
@@ -174,12 +184,14 @@ private _state = createHashMapFromArray [
     ["packageNumber", 0],
     ["retaskedTotal", 0],
     ["stuckTotal", 0],
+    ["mergedGroupsTotal", 0],
+    ["mergedUnitsTotal", 0],
     ["nextScalingCheck", _now + (_config get "initialDelay")],
     ["nextInfantryCheck", _now + (_config get "initialDelay")],
     ["nextVehicleCheck", _now + (_config get "initialDelay") + (_config get "vehicleEvaluationOffset")],
     ["nextBehaviorCheck", _now + (_config get "initialDelay") + 5],
     ["nextStatusLog", _now + (_config get "statusLogInterval")],
-    ["snapshot", createHashMap]
+    ["snapshot", createHashMapFromArray [["running", true], ["paused", false]]]
 ];
 
 missionNamespace setVariable [_stateName, _state];
@@ -418,8 +430,127 @@ private _fnc_evaluate = {
     private _infantryDeficit = (_desiredInfantry - _effectiveInfantry) max 0;
     private _vehicleDeficit = (_desiredVehicles - _effectiveVehicles) max 0;
 
+    private _mergedGroupsThisCheck = 0;
+    private _mergedUnitsThisCheck = 0;
     private _retaskedThisCheck = 0;
     private _stuckThisCheck = 0;
+
+    if (
+        _behaviorDue
+        && { _config getOrDefault ["mergeEnabled", true] }
+        && { !(_infantryGroups isEqualTo []) }
+    ) then {
+        private _mergeThreshold = (round (_config getOrDefault ["mergeThreshold", 5])) max 1;
+        private _mergeSearchRadius = (_config getOrDefault ["mergeSearchRadius", 300]) max 0;
+        private _defaultMaximumSize = (round (_config getOrDefault ["maximumMergedGroupSize", 30])) max _mergeThreshold;
+        private _enemyExclusionRadius = (_config get "stuckEnemyExclusionRadius") max 0;
+
+        private _fnc_groupBusy = {
+            params ["_group"];
+
+            private _leader = leader _group;
+            if (isNull _leader) exitWith { true };
+
+            private _lambsTask = _leader getVariable ["lambs_main_currentTask", ""];
+            private _activeCQB = (_lambsTask find "Clearing rooms") >= 0
+                || { (_lambsTask find "Rush enemy") >= 0 };
+            private _nearestEnemy = _leader findNearestEnemy (getPosATL _leader);
+            private _enemyNearby = !isNull _nearestEnemy
+                && { _leader distance2D _nearestEnemy <= _enemyExclusionRadius };
+
+            _activeCQB || _enemyNearby
+        };
+
+        private _sourceGroups = +(_infantryGroups select {
+            _x getVariable ["TMC_attackWaveAllowMerge", false]
+            && {
+                private _living = { alive _x } count units _x;
+                _living > 0 && { _living < _mergeThreshold }
+            }
+        });
+
+        {
+            private _sourceGroup = _x;
+            private _sourceUnits = units _sourceGroup select { alive _x };
+            private _sourceCount = count _sourceUnits;
+            private _sourceLeader = leader _sourceGroup;
+
+            if (
+                _sourceCount > 0
+                && { _sourceCount < _mergeThreshold }
+                && { !isNull _sourceLeader }
+                && { !([_sourceGroup] call _fnc_groupBusy) }
+            ) then {
+                private _eligibleGroups = _infantryGroups select {
+                    private _destinationGroup = _x;
+                    private _destinationLeader = leader _destinationGroup;
+                    private _destinationCount = { alive _x } count units _destinationGroup;
+                    private _destinationMaximum = (
+                        round (_destinationGroup getVariable [
+                            "TMC_attackWaveMaximumMergedSize",
+                            _defaultMaximumSize
+                        ])
+                    ) max _mergeThreshold;
+
+                    !(_destinationGroup isEqualTo _sourceGroup)
+                    && { !isNull _destinationGroup }
+                    && { !isNull _destinationLeader }
+                    && { _destinationGroup getVariable ["TMC_attackWaveAllowMerge", false] }
+                    && { _destinationCount > 0 }
+                    && { _destinationCount + _sourceCount <= _destinationMaximum }
+                    && { _sourceLeader distance2D _destinationLeader <= _mergeSearchRadius }
+                    && { !([_destinationGroup] call _fnc_groupBusy) }
+                };
+
+                private _establishedGroups = _eligibleGroups select {
+                    ({ alive _x } count units _x) >= _mergeThreshold
+                };
+                private _destinationPool = if (_establishedGroups isEqualTo []) then {
+                    _eligibleGroups
+                } else {
+                    _establishedGroups
+                };
+
+                if !(_destinationPool isEqualTo []) then {
+                    private _destinationGroup = _destinationPool select 0;
+                    private _bestDistance = _sourceLeader distance2D leader _destinationGroup;
+
+                    {
+                        private _distance = _sourceLeader distance2D leader _x;
+                        if (_distance < _bestDistance) then {
+                            _destinationGroup = _x;
+                            _bestDistance = _distance;
+                        };
+                    } forEach _destinationPool;
+
+                    _sourceGroup setVariable ["TMC_attackWaveAllowMerge", false];
+                    _sourceUnits joinSilent _destinationGroup;
+
+                    private _destinationLeader = leader _destinationGroup;
+                    {
+                        if (alive _x && { !isNull _destinationLeader }) then {
+                            _x doFollow _destinationLeader;
+                        };
+                    } forEach _sourceUnits;
+
+                    _destinationGroup setVariable ["TMC_attackWaveAllowMerge", true];
+                    _destinationGroup setVariable ["TMC_attackWaveTemplate", "Merged regular infantry"];
+
+                    if ((units _sourceGroup) isEqualTo []) then {
+                        deleteGroup _sourceGroup;
+                    };
+
+                    _mergedGroupsThisCheck = _mergedGroupsThisCheck + 1;
+                    _mergedUnitsThisCheck = _mergedUnitsThisCheck + _sourceCount;
+                };
+            };
+        } forEach _sourceGroups;
+
+        _infantryGroups = _infantryGroups select {
+            !isNull _x && { units _x findIf { alive _x } >= 0 }
+        };
+        _state set ["infantryGroups", _infantryGroups];
+    };
 
     if (_behaviorDue && { !(_infantryGroups isEqualTo []) }) then {
         private _groundPlayers = ([] call CBA_fnc_players) select {
@@ -634,9 +765,15 @@ private _fnc_evaluate = {
         + _retaskedThisCheck;
     private _stuckTotal = (_state getOrDefault ["stuckTotal", 0])
         + _stuckThisCheck;
+    private _mergedGroupsTotal = (_state getOrDefault ["mergedGroupsTotal", 0])
+        + _mergedGroupsThisCheck;
+    private _mergedUnitsTotal = (_state getOrDefault ["mergedUnitsTotal", 0])
+        + _mergedUnitsThisCheck;
 
     _state set ["retaskedTotal", _retaskedTotal];
     _state set ["stuckTotal", _stuckTotal];
+    _state set ["mergedGroupsTotal", _mergedGroupsTotal];
+    _state set ["mergedUnitsTotal", _mergedUnitsTotal];
 
     private _usedSharedSlots = count _infantryGroups
         + count _vehicleGroups
@@ -750,6 +887,10 @@ private _fnc_evaluate = {
         ["vehicleGroups", count _vehicleGroups],
         ["pendingInfantryPackages", count _infantryHandles],
         ["pendingVehiclePackages", count _vehicleHandles],
+        ["mergedGroupsThisCheck", _mergedGroupsThisCheck],
+        ["mergedUnitsThisCheck", _mergedUnitsThisCheck],
+        ["mergedGroupsTotal", _mergedGroupsTotal],
+        ["mergedUnitsTotal", _mergedUnitsTotal],
         ["retaskedThisCheck", _retaskedThisCheck],
         ["stuckThisCheck", _stuckThisCheck],
         ["retaskedTotal", _retaskedTotal],
@@ -764,10 +905,16 @@ private _fnc_evaluate = {
 
     if (
         _debugMode in ["LOG", "MARKERS"]
-        && { _retaskedThisCheck > 0 || { _stuckThisCheck > 0 } }
+        && {
+            _mergedGroupsThisCheck > 0
+            || { _retaskedThisCheck > 0 }
+            || { _stuckThisCheck > 0 }
+        }
     ) then {
         diag_log format [
-            "[TMC v5 Director] Behavior check retasked %1 groups and recovered %2 stuck groups.",
+            "[TMC v5 Director] Behavior check merged %1 groups (%2 units), retasked %3 groups, and recovered %4 stuck groups.",
+            _mergedGroupsThisCheck,
+            _mergedUnitsThisCheck,
             _retaskedThisCheck,
             _stuckThisCheck
         ];
@@ -788,7 +935,7 @@ _state set ["pfhHandle", _pfhHandle];
 missionNamespace setVariable [_stateName, _state];
 
 diag_log format [
-    "[TMC v5 Director] Started. Scaling every %1s. Infantry %2:1 every %3s. Vehicles 1:%4 every %5s with %6s offset. Behavior checks every %7s.",
+    "[TMC v5 Director] Started. Scaling every %1s. Infantry %2:1 every %3s. Vehicles 1:%4 every %5s with %6s offset. Behavior and merge checks every %7s.",
     _config get "scalingEvaluationInterval",
     _config get "enemyRatio",
     _config get "infantryEvaluationInterval",

--- a/TMC_ContinuousDirector_v5/TMC_ContinuousDirector.sqf
+++ b/TMC_ContinuousDirector_v5/TMC_ContinuousDirector.sqf
@@ -53,6 +53,10 @@ private _defaults = createHashMapFromArray [
     ["infantryEvaluationInterval",5],
     ["vehicleEvaluationInterval",10],
     ["vehicleEvaluationOffset",2.5],
+    ["behaviorEvaluationInterval",20],
+    ["stuckTimeout",75],
+    ["stuckMovementDistance",20],
+    ["targetMoveThreshold",35],
     ["maxDesiredInfantry",-1],
     ["hardInfantryCap",450],
     ["maxActiveVehicles",20],
@@ -84,6 +88,7 @@ private _state = createHashMapFromArray [
     ["packageNumber",0],
     ["nextInfantryCheck",_now + (_config get "initialDelay")],
     ["nextVehicleCheck",_now + (_config get "initialDelay") + (_config get "vehicleEvaluationOffset")],
+    ["nextBehaviorCheck",_now + (_config get "initialDelay") + 5],
     ["snapshot",createHashMap]
 ];
 missionNamespace setVariable [_stateName,_state];
@@ -91,6 +96,7 @@ missionNamespace setVariable [_stateName,_state];
 private _fnc_evaluate = {
     params ["_args","_pfhHandle"];
     _args params ["_stateName"];
+
     private _state = missionNamespace getVariable [_stateName,createHashMap];
     if ((count _state) isEqualTo 0) exitWith { [_pfhHandle] call CBA_fnc_removePerFrameHandler };
     if !(_state getOrDefault ["running",false]) exitWith { [_pfhHandle] call CBA_fnc_removePerFrameHandler };
@@ -102,9 +108,11 @@ private _fnc_evaluate = {
     private _scalingSide = _config get "scalingSide";
     private _enemySide = _config get "enemySide";
     private _mode = toUpper (_config get "scalingMode");
+
     private _sideUnits = allUnits select {
         alive _x && {side group _x isEqualTo _scalingSide}
     };
+
     private _scalingUnits = switch (_mode) do {
         case "SIDE": {_sideUnits};
         case "RADIUS": {_sideUnits select {_x distance2D _centerPos <= (_config get "scalingRadius")}};
@@ -133,10 +141,12 @@ private _fnc_evaluate = {
     private _vehicleGroups = _managedGroups select {
         toUpper (_x getVariable ["TMC_attackWaveKind",""]) isEqualTo "VEHICLE"
     };
+
     private _infantryCount = 0;
     {
         _infantryCount = _infantryCount + ({alive _x && {side group _x isEqualTo _enemySide}} count units _x);
     } forEach _infantryGroups;
+
     private _managedVehicles = vehicles select {
         alive _x
         && {_x getVariable ["TMC_attackWaveVehicle",false]}
@@ -161,11 +171,104 @@ private _fnc_evaluate = {
     private _now = diag_tickTime;
     private _infantryDue = _now >= (_state get "nextInfantryCheck");
     private _vehicleDue = _now >= (_state get "nextVehicleCheck");
+    private _behaviorDue = _now >= (_state get "nextBehaviorCheck");
+
     if (_infantryDue) then {
         _state set ["nextInfantryCheck",_now + (_config get "infantryEvaluationInterval")];
     };
     if (_vehicleDue) then {
         _state set ["nextVehicleCheck",_now + (_config get "vehicleEvaluationInterval")];
+    };
+    if (_behaviorDue) then {
+        _state set ["nextBehaviorCheck",_now + (_config get "behaviorEvaluationInterval")];
+    };
+
+    private _retaskedGroups = 0;
+    private _stuckGroups = 0;
+
+    if (_behaviorDue && {!(_infantryGroups isEqualTo [])}) then {
+        private _aircraft = vehicles select { alive _x && {_x isKindOf "Air"} };
+        private _groundPlayers = ([] call CBA_fnc_players) select {
+            alive _x
+            && {side group _x isEqualTo _scalingSide}
+            && {!((vehicle _x) isKindOf "Air")}
+        };
+        private _groundLeaders = _groundPlayers select { leader group _x isEqualTo _x };
+        private _targetPool = if (_groundLeaders isEqualTo []) then {_groundPlayers} else {_groundLeaders};
+
+        {
+            private _group = _x;
+            private _leader = leader _group;
+
+            if (!isNull _leader) then {
+                _group setBehaviourStrong "AWARE";
+                _group setCombatMode "YELLOW";
+                _group setSpeedMode "FULL";
+                _group enableAttack false;
+                _group allowFleeing 0;
+
+                {
+                    _group ignoreTarget _x;
+                } forEach _aircraft;
+
+                private _target = objNull;
+                if !(_targetPool isEqualTo []) then {
+                    _target = _targetPool select 0;
+                    private _bestDistance = _leader distance2D _target;
+                    {
+                        private _distance = _leader distance2D _x;
+                        if (_distance < _bestDistance) then {
+                            _target = _x;
+                            _bestDistance = _distance;
+                        };
+                    } forEach _targetPool;
+                };
+
+                private _targetPos = if (isNull _target) then {+_centerPos} else {getPosATL _target};
+                _targetPos resize 3;
+                _targetPos set [2,0];
+
+                private _waypoint = _group getVariable ["TMC_attackWaypoint",[]];
+                if !(_waypoint isEqualTo []) then {
+                    private _oldTargetPos = _group getVariable ["TMC_attackTargetPosition",_targetPos];
+                    if (_oldTargetPos distance2D _targetPos >= (_config get "targetMoveThreshold")) then {
+                        _waypoint setWaypointPosition [_targetPos,-1];
+                        _group setCurrentWaypoint _waypoint;
+                        _group move _targetPos;
+                        _group setVariable ["TMC_attackTargetPosition",_targetPos];
+                        _group setVariable ["TMC_attackTarget",_target];
+                        _group setVariable ["TMC_lastRetaskTime",_now];
+                        _retaskedGroups = _retaskedGroups + 1;
+                    };
+                };
+
+                private _lastPosition = _group getVariable ["TMC_lastLeaderPosition",getPosATL _leader];
+                private _lastProgress = _group getVariable ["TMC_lastProgressTime",_now];
+
+                if (_leader distance2D _lastPosition >= (_config get "stuckMovementDistance")) then {
+                    _group setVariable ["TMC_lastLeaderPosition",getPosATL _leader];
+                    _group setVariable ["TMC_lastProgressTime",_now];
+                } else {
+                    if (_now - _lastProgress >= (_config get "stuckTimeout")) then {
+                        _stuckGroups = _stuckGroups + 1;
+                        if !(_waypoint isEqualTo []) then {
+                            _waypoint setWaypointPosition [_targetPos,-1];
+                            _group setCurrentWaypoint _waypoint;
+                        };
+                        {
+                            if (alive _x) then {
+                                _x forceSpeed -1;
+                                _x doFollow _leader;
+                            };
+                        } forEach units _group;
+                        _group move _targetPos;
+                        _group setVariable ["TMC_lastLeaderPosition",getPosATL _leader];
+                        _group setVariable ["TMC_lastProgressTime",_now];
+                        _group setVariable ["TMC_lastRetaskTime",_now];
+                    };
+                };
+            };
+        } forEach _infantryGroups;
     };
 
     private _sharedUsed = count _managedGroups + count _infantryHandles + count _vehicleHandles;
@@ -231,6 +334,8 @@ private _fnc_evaluate = {
         ["vehicleDeficit",_vehicleDeficit],
         ["infantryGroups",count _infantryGroups],
         ["vehicleGroups",count _vehicleGroups],
+        ["retaskedGroups",_retaskedGroups],
+        ["stuckGroups",_stuckGroups],
         ["sentInfantry",_sentInfantry],
         ["sentVehicle",_sentVehicle],
         ["fps",diag_fps]
@@ -248,10 +353,11 @@ _state set ["pfhHandle",_pfh];
 missionNamespace setVariable [_stateName,_state];
 
 diag_log format [
-    "[TMC v5 Director] Started. Infantry %1:1 every %2s. Vehicles 1:%3 every %4s with %5s offset.",
+    "[TMC v5 Director] Started. Infantry %1:1 every %2s. Vehicles 1:%3 every %4s with %5s offset. Behavior checks every %6s.",
     _config get "enemyRatio",
     _config get "infantryEvaluationInterval",
     _config get "scalingUnitsPerVehicle",
     _config get "vehicleEvaluationInterval",
-    _config get "vehicleEvaluationOffset"
+    _config get "vehicleEvaluationOffset",
+    _config get "behaviorEvaluationInterval"
 ];

--- a/TMC_ContinuousDirector_v5/TMC_fnc_spawnAttackWave.sqf
+++ b/TMC_ContinuousDirector_v5/TMC_fnc_spawnAttackWave.sqf
@@ -1,0 +1,292 @@
+params [["_userConfig", createHashMap]];
+
+if (!isServer) exitWith { createHashMapFromArray [["success",false],["groups",[]],["vehicles",[]],["failedSpawns",[]]] };
+if !(_userConfig isEqualType createHashMap) exitWith { createHashMapFromArray [["success",false],["groups",[]],["vehicles",[]],["failedSpawns",[]]] };
+
+private _defaults = createHashMapFromArray [
+    ["center", objNull],
+    ["side", east],
+    ["minSpawnRadius", 500],
+    ["maxSpawnRadius", 850],
+    ["minPlayerDistance", 225],
+    ["visibilityMaxDistance", 1500],
+    ["visibilityThreshold", 0.05],
+    ["attemptsPerGroup", 40],
+    ["groupSeparation", 45],
+    ["infantryGroupCount", 1],
+    ["vehicleGroupCount", 0],
+    ["infantryTemplates", []],
+    ["vehicleTemplates", []],
+    ["attackMode", "LAMBS"],
+    ["searchRadius", 250],
+    ["lambsReinforcement", true],
+    ["lambsKnowledgeSeedChance", 0.25],
+    ["spawnDelay", 0.20],
+    ["debugMode", "LOG"],
+    ["waveId", -1],
+    ["onGroupSpawned", {}],
+    ["onComplete", {}]
+];
+
+private _config = createHashMap;
+{ _config set [_x, _defaults get _x] } forEach keys _defaults;
+{ _config set [_x, _userConfig get _x] } forEach keys _userConfig;
+
+private _centerRef = _config get "center";
+private _centerPos = _centerRef call CBA_fnc_getPos;
+if ((count _centerPos) < 2) exitWith { createHashMapFromArray [["success",false],["groups",[]],["vehicles",[]],["failedSpawns",["INVALID_CENTER"]]] };
+_centerPos resize 3;
+_centerPos set [2,0];
+
+private _side = _config get "side";
+private _minRadius = (_config get "minSpawnRadius") max 0;
+private _maxRadius = (_config get "maxSpawnRadius") max _minRadius;
+private _minPlayerDistance = (_config get "minPlayerDistance") max 0;
+private _visibilityMaxDistance = (_config get "visibilityMaxDistance") max 0;
+private _visibilityThreshold = _config get "visibilityThreshold";
+private _attempts = round ((_config get "attemptsPerGroup") max 1);
+private _groupSeparation = (_config get "groupSeparation") max 0;
+private _debugMode = toUpper (_config get "debugMode");
+private _spawnDelay = (_config get "spawnDelay") max 0;
+private _reserved = [];
+private _spawnedGroups = [];
+private _spawnedVehicles = [];
+private _failed = [];
+
+private _fnc_log = {
+    params ["_text"];
+    if (_debugMode in ["LOG","MARKERS"]) then { diag_log format ["[TMC v5 Spawner] %1",_text] };
+};
+
+private _fnc_pickWeighted = {
+    params ["_templates"];
+    private _weighted = [];
+    {
+        private _weight = _x getOrDefault ["weight",1];
+        if (_weight > 0) then { _weighted append [_x,_weight] };
+    } forEach _templates;
+    if (_weighted isEqualTo []) exitWith { createHashMap };
+    _weighted call BIS_fnc_selectRandomWeighted
+};
+
+private _fnc_hidden = {
+    params ["_candidate","_kind","_sampleRadius","_sampleHeight"];
+    private _players = ([] call CBA_fnc_players) select {
+        alive _x && { _x distance2D _candidate <= _visibilityMaxDistance }
+    };
+    if (_players isEqualTo []) exitWith { true };
+    private _samples = [
+        [0,0,0],
+        [_sampleRadius,0,0],
+        [-_sampleRadius,0,0],
+        [0,_sampleRadius,0],
+        [0,-_sampleRadius,0]
+    ];
+    private _heights = [_sampleHeight];
+    if (_kind isEqualTo "VEHICLE") then { _heights pushBack (_sampleHeight + 1.5) };
+    private _hidden = true;
+    {
+        private _viewer = _x;
+        private _eye = eyePos _viewer;
+        {
+            private _height = _x;
+            {
+                private _targetAGL = [
+                    (_candidate select 0) + (_x select 0),
+                    (_candidate select 1) + (_x select 1),
+                    _height
+                ];
+                private _ignored = vehicle _viewer;
+                if (_ignored isEqualTo _viewer) then { _ignored = objNull };
+                private _vis = [_viewer,"VIEW",_ignored] checkVisibility [_eye,AGLToASL _targetAGL];
+                if (_vis > _visibilityThreshold) exitWith { _hidden = false };
+            } forEach _samples;
+            if (!_hidden) exitWith {};
+        } forEach _heights;
+        if (!_hidden) exitWith {};
+    } forEach _players;
+    _hidden
+};
+
+private _fnc_findPosition = {
+    params ["_kind","_template"];
+    private _vehicle = _kind isEqualTo "VEHICLE";
+    private _objectClearance = _template getOrDefault ["objectClearance",if (_vehicle) then {15} else {8}];
+    private _terrainClearance = _template getOrDefault ["terrainClearance",if (_vehicle) then {8} else {3}];
+    private _maxGradient = _template getOrDefault ["maxGradient",if (_vehicle) then {0.16} else {0.32}];
+    private _sampleRadius = _template getOrDefault ["visibilityRadius",if (_vehicle) then {14} else {14}];
+    private _sampleHeight = _template getOrDefault ["visibilityHeight",if (_vehicle) then {2.5} else {1.3}];
+    private _accepted = [];
+    for "_attempt" from 1 to _attempts do {
+        private _candidate = [_centerPos,_minRadius,_maxRadius,_objectClearance,0,_maxGradient,0,[],[[0,0,0],[0,0,0]]] call BIS_fnc_findSafePos;
+        private _valid = !(_candidate isEqualTo [0,0,0]);
+        if (_valid) then {
+            _candidate resize 3;
+            _candidate set [2,0];
+            if (_vehicle && {_template getOrDefault ["preferRoad",true]}) then {
+                private _roads = _candidate nearRoads (_template getOrDefault ["roadSearchRadius",75]);
+                if (_roads isEqualTo []) then { _valid = false } else { _candidate = getPosATL (_roads select 0) };
+            };
+        };
+        private _players = ([] call CBA_fnc_players) select { alive _x };
+        if (_valid && {_players findIf {_x distance2D _candidate < _minPlayerDistance} >= 0}) then { _valid = false };
+        if (_valid && {_reserved findIf {_x distance2D _candidate < _groupSeparation} >= 0}) then { _valid = false };
+        if (_valid && {surfaceIsWater _candidate}) then { _valid = false };
+        if (_valid && {!((nearestObjects [_candidate,["Man","LandVehicle","Air","Ship","StaticWeapon","Building","House","ThingX"],_objectClearance,true]) isEqualTo [])}) then { _valid = false };
+        if (_valid && {!((nearestTerrainObjects [_candidate,["BUILDING","BUNKER","FENCE","FORTRESS","HOUSE","ROCK","ROCKS","TREE","WALL"],_terrainClearance,false,true]) isEqualTo [])}) then { _valid = false };
+        if (_valid && {!([_candidate,_kind,_sampleRadius,_sampleHeight] call _fnc_hidden)}) then { _valid = false };
+        if (_valid) exitWith { _accepted = _candidate };
+    };
+    _accepted
+};
+
+private _fnc_prepareInfantry = {
+    params ["_group"];
+    _group setBehaviourStrong "COMBAT";
+    _group setCombatMode "RED";
+    _group setSpeedMode "FULL";
+    _group enableAttack true;
+    if (_config get "lambsReinforcement") then {
+        _group setVariable ["lambs_danger_enableGroupReinforce",true,true];
+    };
+    {
+        _x enableStamina false;
+        _x enableFatigue false;
+        _x forceSpeed -1;
+        _x setUnitPos "AUTO";
+        _x enableAI "MOVE";
+        _x enableAI "PATH";
+        _x enableAI "FSM";
+        _x enableAI "AUTOCOMBAT";
+        _x enableAI "TARGET";
+        _x enableAI "AUTOTARGET";
+        _x enableAI "SUPPRESSION";
+        _x setVariable ["lambs_danger_dangerRadio",true,true];
+    } forEach units _group;
+};
+
+private _fnc_taskInfantry = {
+    params ["_group"];
+    [_group] call _fnc_prepareInfantry;
+    if (!isNil "lambs_wp_fnc_taskAssault") then {
+        [_group,_centerPos] spawn lambs_wp_fnc_taskAssault;
+    } else {
+        private _wp = _group addWaypoint [_centerPos,_config get "searchRadius"];
+        _wp setWaypointType "SAD";
+        _wp setWaypointBehaviour "COMBAT";
+        _wp setWaypointCombatMode "RED";
+        _wp setWaypointSpeed "FULL";
+    };
+    if (random 1 < (_config get "lambsKnowledgeSeedChance")) then {
+        private _targets = ([] call CBA_fnc_players) select { alive _x };
+        if !(_targets isEqualTo []) then {
+            private _leader = leader _group;
+            private _nearest = _targets select 0;
+            { if (_leader distance2D _x < _leader distance2D _nearest) then { _nearest = _x } } forEach _targets;
+            _leader reveal [_nearest,1.25];
+        };
+    };
+};
+
+private _fnc_taskVehicle = {
+    params ["_group"];
+    _group setBehaviourStrong "AWARE";
+    _group setCombatMode "RED";
+    _group setSpeedMode "FULL";
+    private _wp = _group addWaypoint [_centerPos,_config get "searchRadius"];
+    _wp setWaypointType "SAD";
+    _wp setWaypointBehaviour "COMBAT";
+    _wp setWaypointCombatMode "RED";
+    _wp setWaypointSpeed "FULL";
+};
+
+private _fnc_spawnInfantry = {
+    params ["_template","_position"];
+    private _classes = +(_template getOrDefault ["units",[]]);
+    if (_classes isEqualTo []) exitWith { grpNull };
+    private _group = [_position,_side,_classes,[],[],[],[],[],_position getDir _centerPos,true] call BIS_fnc_spawnGroup;
+    if (isNull _group) exitWith { grpNull };
+    _group deleteGroupWhenEmpty true;
+    _group setFormation (_template getOrDefault ["formation","STAG COLUMN"]);
+    private _skill = _template getOrDefault ["skill",[0.4,0.55]];
+    {
+        private _value = if (_skill isEqualType []) then { (_skill select 0) + random ((_skill select 1)-(_skill select 0)) } else { _skill };
+        _x setSkill ((_value max 0) min 1);
+    } forEach units _group;
+    [_group] call _fnc_taskInfantry;
+    _group
+};
+
+private _fnc_spawnVehicle = {
+    params ["_template","_position"];
+    private _class = _template getOrDefault ["vehicleClass",""];
+    if (_class isEqualTo "") exitWith { [objNull,grpNull] };
+    private _vehicle = createVehicle [_class,_position,[],0,"NONE"];
+    if (isNull _vehicle) exitWith { [objNull,grpNull] };
+    _vehicle setDir (_position getDir _centerPos);
+    createVehicleCrew _vehicle;
+    private _group = group effectiveCommander _vehicle;
+    if (isNull _group) then {
+        deleteVehicle _vehicle;
+        [objNull,grpNull]
+    } else {
+        _group deleteGroupWhenEmpty true;
+        [_group] call _fnc_taskVehicle;
+        [_vehicle,_group]
+    }
+};
+
+for "_index" from 1 to round (_config get "infantryGroupCount") do {
+    private _template = [_config get "infantryTemplates"] call _fnc_pickWeighted;
+    if ((count _template) isEqualTo 0) then {
+        _failed pushBack ["INFANTRY",_index,"NO_TEMPLATE"];
+    } else {
+        private _position = ["INFANTRY",_template] call _fnc_findPosition;
+        if (_position isEqualTo []) then {
+            _failed pushBack ["INFANTRY",_index,"NO_POSITION"];
+        } else {
+            private _group = [_template,_position] call _fnc_spawnInfantry;
+            if (isNull _group) then {
+                _failed pushBack ["INFANTRY",_index,"SPAWN_FAILED"];
+            } else {
+                _reserved pushBack _position;
+                _spawnedGroups pushBack _group;
+                [_group,"INFANTRY",_template,_position,objNull,_config] call (_config get "onGroupSpawned");
+            };
+        };
+    };
+    if (_spawnDelay > 0) then { sleep _spawnDelay };
+};
+
+for "_index" from 1 to round (_config get "vehicleGroupCount") do {
+    private _template = [_config get "vehicleTemplates"] call _fnc_pickWeighted;
+    if ((count _template) isEqualTo 0) then {
+        _failed pushBack ["VEHICLE",_index,"NO_TEMPLATE"];
+    } else {
+        private _position = ["VEHICLE",_template] call _fnc_findPosition;
+        if (_position isEqualTo []) then {
+            _failed pushBack ["VEHICLE",_index,"NO_POSITION"];
+        } else {
+            private _spawn = [_template,_position] call _fnc_spawnVehicle;
+            _spawn params ["_vehicle","_group"];
+            if (isNull _vehicle || {isNull _group}) then {
+                _failed pushBack ["VEHICLE",_index,"SPAWN_FAILED"];
+            } else {
+                _reserved pushBack _position;
+                _spawnedVehicles pushBack _vehicle;
+                _spawnedGroups pushBack _group;
+                [_group,"VEHICLE",_template,_position,_vehicle,_config] call (_config get "onGroupSpawned");
+            };
+        };
+    };
+    if (_spawnDelay > 0) then { sleep _spawnDelay };
+};
+
+private _result = createHashMapFromArray [
+    ["success",true],
+    ["groups",_spawnedGroups],
+    ["vehicles",_spawnedVehicles],
+    ["failedSpawns",_failed]
+];
+[_result,_config] call (_config get "onComplete");
+_result

--- a/TMC_ContinuousDirector_v5/TMC_fnc_spawnAttackWave.sqf
+++ b/TMC_ContinuousDirector_v5/TMC_fnc_spawnAttackWave.sqf
@@ -6,6 +6,7 @@ if !(_userConfig isEqualType createHashMap) exitWith { createHashMapFromArray [[
 private _defaults = createHashMapFromArray [
     ["center", objNull],
     ["side", east],
+    ["targetSide", west],
     ["minSpawnRadius", 500],
     ["maxSpawnRadius", 850],
     ["minPlayerDistance", 225],
@@ -17,10 +18,11 @@ private _defaults = createHashMapFromArray [
     ["vehicleGroupCount", 0],
     ["infantryTemplates", []],
     ["vehicleTemplates", []],
-    ["attackMode", "LAMBS"],
     ["searchRadius", 250],
+    ["cqbRadius", 75],
     ["lambsReinforcement", true],
     ["lambsKnowledgeSeedChance", 0.25],
+    ["ignoreAircraft", true],
     ["spawnDelay", 0.20],
     ["debugMode", "LOG"],
     ["waveId", -1],
@@ -39,6 +41,7 @@ _centerPos resize 3;
 _centerPos set [2,0];
 
 private _side = _config get "side";
+private _targetSide = _config get "targetSide";
 private _minRadius = (_config get "minSpawnRadius") max 0;
 private _maxRadius = (_config get "maxSpawnRadius") max _minRadius;
 private _minPlayerDistance = (_config get "minPlayerDistance") max 0;
@@ -75,6 +78,7 @@ private _fnc_hidden = {
         alive _x && { _x distance2D _candidate <= _visibilityMaxDistance }
     };
     if (_players isEqualTo []) exitWith { true };
+
     private _samples = [
         [0,0,0],
         [_sampleRadius,0,0],
@@ -84,6 +88,7 @@ private _fnc_hidden = {
     ];
     private _heights = [_sampleHeight];
     if (_kind isEqualTo "VEHICLE") then { _heights pushBack (_sampleHeight + 1.5) };
+
     private _hidden = true;
     {
         private _viewer = _x;
@@ -117,18 +122,27 @@ private _fnc_findPosition = {
     private _sampleRadius = _template getOrDefault ["visibilityRadius",if (_vehicle) then {14} else {14}];
     private _sampleHeight = _template getOrDefault ["visibilityHeight",if (_vehicle) then {2.5} else {1.3}];
     private _accepted = [];
+
+    private _players = ([] call CBA_fnc_players) select { alive _x };
+
     for "_attempt" from 1 to _attempts do {
         private _candidate = [_centerPos,_minRadius,_maxRadius,_objectClearance,0,_maxGradient,0,[],[[0,0,0],[0,0,0]]] call BIS_fnc_findSafePos;
         private _valid = !(_candidate isEqualTo [0,0,0]);
+
         if (_valid) then {
             _candidate resize 3;
             _candidate set [2,0];
             if (_vehicle && {_template getOrDefault ["preferRoad",true]}) then {
                 private _roads = _candidate nearRoads (_template getOrDefault ["roadSearchRadius",75]);
-                if (_roads isEqualTo []) then { _valid = false } else { _candidate = getPosATL (_roads select 0) };
+                if (_roads isEqualTo []) then {
+                    _valid = false;
+                } else {
+                    _candidate = getPosATL (_roads select 0);
+                    _candidate set [2,0];
+                };
             };
         };
-        private _players = ([] call CBA_fnc_players) select { alive _x };
+
         if (_valid && {_players findIf {_x distance2D _candidate < _minPlayerDistance} >= 0}) then { _valid = false };
         if (_valid && {_reserved findIf {_x distance2D _candidate < _groupSeparation} >= 0}) then { _valid = false };
         if (_valid && {surfaceIsWater _candidate}) then { _valid = false };
@@ -140,15 +154,53 @@ private _fnc_findPosition = {
     _accepted
 };
 
+private _fnc_nearestGroundLeader = {
+    params ["_group"];
+    private _source = leader _group;
+    if (isNull _source) exitWith { objNull };
+
+    private _players = ([] call CBA_fnc_players) select {
+        alive _x
+        && {side group _x isEqualTo _targetSide}
+        && {!((vehicle _x) isKindOf "Air")}
+    };
+    if (_players isEqualTo []) exitWith { objNull };
+
+    private _leaders = _players select { leader group _x isEqualTo _x };
+    private _pool = if (_leaders isEqualTo []) then { _players } else { _leaders };
+    private _nearest = _pool select 0;
+    private _bestDistance = _source distance2D _nearest;
+
+    {
+        private _distance = _source distance2D _x;
+        if (_distance < _bestDistance) then {
+            _nearest = _x;
+            _bestDistance = _distance;
+        };
+    } forEach _pool;
+    _nearest
+};
+
+private _fnc_ignoreAircraft = {
+    params ["_group"];
+    if !(_config get "ignoreAircraft") exitWith {};
+    {
+        _group ignoreTarget _x;
+    } forEach (vehicles select { alive _x && {_x isKindOf "Air"} });
+};
+
 private _fnc_prepareInfantry = {
     params ["_group"];
-    _group setBehaviourStrong "COMBAT";
-    _group setCombatMode "RED";
+    _group setBehaviourStrong "AWARE";
+    _group setCombatMode "YELLOW";
     _group setSpeedMode "FULL";
-    _group enableAttack true;
+    _group enableAttack false;
+    _group allowFleeing 0;
+
     if (_config get "lambsReinforcement") then {
         _group setVariable ["lambs_danger_enableGroupReinforce",true,true];
     };
+
     {
         _x enableStamina false;
         _x enableFatigue false;
@@ -163,28 +215,38 @@ private _fnc_prepareInfantry = {
         _x enableAI "SUPPRESSION";
         _x setVariable ["lambs_danger_dangerRadio",true,true];
     } forEach units _group;
+
+    [_group] call _fnc_ignoreAircraft;
 };
 
 private _fnc_taskInfantry = {
     params ["_group"];
     [_group] call _fnc_prepareInfantry;
-    if (!isNil "lambs_wp_fnc_taskAssault") then {
-        [_group,_centerPos] spawn lambs_wp_fnc_taskAssault;
-    } else {
-        private _wp = _group addWaypoint [_centerPos,_config get "searchRadius"];
-        _wp setWaypointType "SAD";
-        _wp setWaypointBehaviour "COMBAT";
-        _wp setWaypointCombatMode "RED";
-        _wp setWaypointSpeed "FULL";
-    };
-    if (random 1 < (_config get "lambsKnowledgeSeedChance")) then {
-        private _targets = ([] call CBA_fnc_players) select { alive _x };
-        if !(_targets isEqualTo []) then {
-            private _leader = leader _group;
-            private _nearest = _targets select 0;
-            { if (_leader distance2D _x < _leader distance2D _nearest) then { _nearest = _x } } forEach _targets;
-            _leader reveal [_nearest,1.25];
-        };
+
+    private _target = [_group] call _fnc_nearestGroundLeader;
+    private _targetPos = if (isNull _target) then { +_centerPos } else { getPosATL _target };
+    _targetPos resize 3;
+    _targetPos set [2,0];
+
+    [_group] call CBA_fnc_clearWaypoints;
+    private _waypoint = _group addWaypoint [_targetPos,-1];
+    _waypoint setWaypointType "lambs_danger_CQB";
+    _waypoint setWaypointBehaviour "AWARE";
+    _waypoint setWaypointCombatMode "YELLOW";
+    _waypoint setWaypointSpeed "FULL";
+    _waypoint setWaypointCompletionRadius ((_config get "cqbRadius") max 25);
+    _group setCurrentWaypoint _waypoint;
+    _group move _targetPos;
+
+    _group setVariable ["TMC_attackWaypoint",_waypoint];
+    _group setVariable ["TMC_attackTarget",_target];
+    _group setVariable ["TMC_attackTargetPosition",_targetPos];
+    _group setVariable ["TMC_lastLeaderPosition",getPosATL leader _group];
+    _group setVariable ["TMC_lastProgressTime",diag_tickTime];
+    _group setVariable ["TMC_lastRetaskTime",diag_tickTime];
+
+    if (random 1 < (_config get "lambsKnowledgeSeedChance") && {!isNull _target}) then {
+        (leader _group) reveal [_target,1.25];
     };
 };
 
@@ -204,8 +266,10 @@ private _fnc_spawnInfantry = {
     params ["_template","_position"];
     private _classes = +(_template getOrDefault ["units",[]]);
     if (_classes isEqualTo []) exitWith { grpNull };
+
     private _group = [_position,_side,_classes,[],[],[],[],[],_position getDir _centerPos,true] call BIS_fnc_spawnGroup;
     if (isNull _group) exitWith { grpNull };
+
     _group deleteGroupWhenEmpty true;
     _group setFormation (_template getOrDefault ["formation","STAG COLUMN"]);
     private _skill = _template getOrDefault ["skill",[0.4,0.55]];
@@ -213,6 +277,7 @@ private _fnc_spawnInfantry = {
         private _value = if (_skill isEqualType []) then { (_skill select 0) + random ((_skill select 1)-(_skill select 0)) } else { _skill };
         _x setSkill ((_value max 0) min 1);
     } forEach units _group;
+
     [_group] call _fnc_taskInfantry;
     _group
 };
@@ -221,11 +286,14 @@ private _fnc_spawnVehicle = {
     params ["_template","_position"];
     private _class = _template getOrDefault ["vehicleClass",""];
     if (_class isEqualTo "") exitWith { [objNull,grpNull] };
+
     private _vehicle = createVehicle [_class,_position,[],0,"NONE"];
     if (isNull _vehicle) exitWith { [objNull,grpNull] };
+
     _vehicle setDir (_position getDir _centerPos);
     createVehicleCrew _vehicle;
     private _group = group effectiveCommander _vehicle;
+
     if (isNull _group) then {
         deleteVehicle _vehicle;
         [objNull,grpNull]

--- a/TMC_ContinuousDirector_v5/TMC_fnc_spawnAttackWave.sqf
+++ b/TMC_ContinuousDirector_v5/TMC_fnc_spawnAttackWave.sqf
@@ -1,7 +1,22 @@
 params [["_userConfig", createHashMap]];
 
-if (!isServer) exitWith { createHashMapFromArray [["success",false],["groups",[]],["vehicles",[]],["failedSpawns",[]]] };
-if !(_userConfig isEqualType createHashMap) exitWith { createHashMapFromArray [["success",false],["groups",[]],["vehicles",[]],["failedSpawns",[]]] };
+if (!isServer) exitWith {
+    createHashMapFromArray [
+        ["success", false],
+        ["groups", []],
+        ["vehicles", []],
+        ["failedSpawns", ["NOT_SERVER"]]
+    ]
+};
+
+if !(_userConfig isEqualType createHashMap) exitWith {
+    createHashMapFromArray [
+        ["success", false],
+        ["groups", []],
+        ["vehicles", []],
+        ["failedSpawns", ["INVALID_CONFIG"]]
+    ]
+};
 
 private _defaults = createHashMapFromArray [
     ["center", objNull],
@@ -22,9 +37,8 @@ private _defaults = createHashMapFromArray [
     ["cqbRadius", 75],
     ["lambsReinforcement", true],
     ["lambsKnowledgeSeedChance", 0.25],
-    ["ignoreAircraft", true],
-    ["spawnDelay", 0.20],
-    ["debugMode", "LOG"],
+    ["spawnDelay", 0],
+    ["debugMode", "NONE"],
     ["waveId", -1],
     ["onGroupSpawned", {}],
     ["onComplete", {}]
@@ -36,9 +50,18 @@ private _config = createHashMap;
 
 private _centerRef = _config get "center";
 private _centerPos = _centerRef call CBA_fnc_getPos;
-if ((count _centerPos) < 2) exitWith { createHashMapFromArray [["success",false],["groups",[]],["vehicles",[]],["failedSpawns",["INVALID_CENTER"]]] };
+
+if ((count _centerPos) < 2) exitWith {
+    createHashMapFromArray [
+        ["success", false],
+        ["groups", []],
+        ["vehicles", []],
+        ["failedSpawns", ["INVALID_CENTER"]]
+    ]
+};
+
 _centerPos resize 3;
-_centerPos set [2,0];
+_centerPos set [2, 0];
 
 private _side = _config get "side";
 private _targetSide = _config get "targetSide";
@@ -49,125 +72,260 @@ private _visibilityMaxDistance = (_config get "visibilityMaxDistance") max 0;
 private _visibilityThreshold = _config get "visibilityThreshold";
 private _attempts = round ((_config get "attemptsPerGroup") max 1);
 private _groupSeparation = (_config get "groupSeparation") max 0;
-private _debugMode = toUpper (_config get "debugMode");
 private _spawnDelay = (_config get "spawnDelay") max 0;
+private _hasLAMBS_CQB = !isNil "lambs_wp_fnc_taskCQB";
+
 private _reserved = [];
 private _spawnedGroups = [];
 private _spawnedVehicles = [];
 private _failed = [];
 
-private _fnc_log = {
-    params ["_text"];
-    if (_debugMode in ["LOG","MARKERS"]) then { diag_log format ["[TMC v5 Spawner] %1",_text] };
+private _livingPlayers = ([] call CBA_fnc_players) select {
+    !isNull _x && { alive _x }
 };
 
 private _fnc_pickWeighted = {
     params ["_templates"];
+
     private _weighted = [];
     {
-        private _weight = _x getOrDefault ["weight",1];
-        if (_weight > 0) then { _weighted append [_x,_weight] };
+        if (_x isEqualType createHashMap) then {
+            private _weight = _x getOrDefault ["weight", 1];
+            if (_weight > 0) then {
+                _weighted append [_x, _weight];
+            };
+        };
     } forEach _templates;
+
     if (_weighted isEqualTo []) exitWith { createHashMap };
     _weighted call BIS_fnc_selectRandomWeighted
 };
 
 private _fnc_hidden = {
-    params ["_candidate","_kind","_sampleRadius","_sampleHeight"];
-    private _players = ([] call CBA_fnc_players) select {
-        alive _x && { _x distance2D _candidate <= _visibilityMaxDistance }
+    params ["_candidate", "_kind", "_sampleRadius", "_sampleHeight", "_players"];
+
+    private _viewers = _players select {
+        _x distance2D _candidate <= _visibilityMaxDistance
     };
-    if (_players isEqualTo []) exitWith { true };
+
+    if (_viewers isEqualTo []) exitWith { true };
 
     private _samples = [
-        [0,0,0],
-        [_sampleRadius,0,0],
-        [-_sampleRadius,0,0],
-        [0,_sampleRadius,0],
-        [0,-_sampleRadius,0]
+        [0, 0, 0],
+        [_sampleRadius, 0, 0],
+        [-_sampleRadius, 0, 0],
+        [0, _sampleRadius, 0],
+        [0, -_sampleRadius, 0]
     ];
+
     private _heights = [_sampleHeight];
-    if (_kind isEqualTo "VEHICLE") then { _heights pushBack (_sampleHeight + 1.5) };
+    if (_kind isEqualTo "VEHICLE") then {
+        _heights pushBack (_sampleHeight + 1.5);
+    };
 
     private _hidden = true;
+
     {
         private _viewer = _x;
         private _eye = eyePos _viewer;
+
         {
             private _height = _x;
+
             {
                 private _targetAGL = [
                     (_candidate select 0) + (_x select 0),
                     (_candidate select 1) + (_x select 1),
                     _height
                 ];
+
                 private _ignored = vehicle _viewer;
-                if (_ignored isEqualTo _viewer) then { _ignored = objNull };
-                private _vis = [_viewer,"VIEW",_ignored] checkVisibility [_eye,AGLToASL _targetAGL];
-                if (_vis > _visibilityThreshold) exitWith { _hidden = false };
+                if (_ignored isEqualTo _viewer) then {
+                    _ignored = objNull;
+                };
+
+                private _visibility = [
+                    _viewer,
+                    "VIEW",
+                    _ignored
+                ] checkVisibility [
+                    _eye,
+                    AGLToASL _targetAGL
+                ];
+
+                if (_visibility > _visibilityThreshold) exitWith {
+                    _hidden = false;
+                };
             } forEach _samples;
+
             if (!_hidden) exitWith {};
         } forEach _heights;
+
         if (!_hidden) exitWith {};
-    } forEach _players;
+    } forEach _viewers;
+
     _hidden
 };
 
 private _fnc_findPosition = {
-    params ["_kind","_template"];
-    private _vehicle = _kind isEqualTo "VEHICLE";
-    private _objectClearance = _template getOrDefault ["objectClearance",if (_vehicle) then {15} else {8}];
-    private _terrainClearance = _template getOrDefault ["terrainClearance",if (_vehicle) then {8} else {3}];
-    private _maxGradient = _template getOrDefault ["maxGradient",if (_vehicle) then {0.16} else {0.32}];
-    private _sampleRadius = _template getOrDefault ["visibilityRadius",if (_vehicle) then {14} else {14}];
-    private _sampleHeight = _template getOrDefault ["visibilityHeight",if (_vehicle) then {2.5} else {1.3}];
-    private _accepted = [];
+    params ["_kind", "_template", "_players"];
 
-    private _players = ([] call CBA_fnc_players) select { alive _x };
+    private _isVehicle = _kind isEqualTo "VEHICLE";
+    private _objectClearance = _template getOrDefault [
+        "objectClearance",
+        if (_isVehicle) then { 15 } else { 8 }
+    ];
+    private _terrainClearance = _template getOrDefault [
+        "terrainClearance",
+        if (_isVehicle) then { 8 } else { 3 }
+    ];
+    private _maxGradient = _template getOrDefault [
+        "maxGradient",
+        if (_isVehicle) then { 0.16 } else { 0.32 }
+    ];
+    private _sampleRadius = _template getOrDefault [
+        "visibilityRadius",
+        14
+    ];
+    private _sampleHeight = _template getOrDefault [
+        "visibilityHeight",
+        if (_isVehicle) then { 2.5 } else { 1.3 }
+    ];
+
+    private _accepted = [];
+    private _failurePosition = [-10000, -10000, 0];
 
     for "_attempt" from 1 to _attempts do {
-        private _candidate = [_centerPos,_minRadius,_maxRadius,_objectClearance,0,_maxGradient,0,[],[[0,0,0],[0,0,0]]] call BIS_fnc_findSafePos;
-        private _valid = !(_candidate isEqualTo [0,0,0]);
+        private _candidate = [
+            _centerPos,
+            _minRadius,
+            _maxRadius,
+            _objectClearance,
+            0,
+            _maxGradient,
+            0,
+            [],
+            [_failurePosition, _failurePosition]
+        ] call BIS_fnc_findSafePos;
+
+        private _valid = !(_candidate isEqualTo _failurePosition);
 
         if (_valid) then {
             _candidate resize 3;
-            _candidate set [2,0];
-            if (_vehicle && {_template getOrDefault ["preferRoad",true]}) then {
-                private _roads = _candidate nearRoads (_template getOrDefault ["roadSearchRadius",75]);
+            _candidate set [2, 0];
+
+            if (_isVehicle && { _template getOrDefault ["preferRoad", true] }) then {
+                private _roads = _candidate nearRoads (_template getOrDefault ["roadSearchRadius", 75]);
+
                 if (_roads isEqualTo []) then {
                     _valid = false;
                 } else {
                     _candidate = getPosATL (_roads select 0);
-                    _candidate set [2,0];
+                    _candidate set [2, 0];
                 };
             };
         };
 
-        if (_valid && {_players findIf {_x distance2D _candidate < _minPlayerDistance} >= 0}) then { _valid = false };
-        if (_valid && {_reserved findIf {_x distance2D _candidate < _groupSeparation} >= 0}) then { _valid = false };
-        if (_valid && {surfaceIsWater _candidate}) then { _valid = false };
-        if (_valid && {!((nearestObjects [_candidate,["Man","LandVehicle","Air","Ship","StaticWeapon","Building","House","ThingX"],_objectClearance,true]) isEqualTo [])}) then { _valid = false };
-        if (_valid && {!((nearestTerrainObjects [_candidate,["BUILDING","BUNKER","FENCE","FORTRESS","HOUSE","ROCK","ROCKS","TREE","WALL"],_terrainClearance,false,true]) isEqualTo [])}) then { _valid = false };
-        if (_valid && {!([_candidate,_kind,_sampleRadius,_sampleHeight] call _fnc_hidden)}) then { _valid = false };
-        if (_valid) exitWith { _accepted = _candidate };
+        if (_valid && { surfaceIsWater _candidate }) then {
+            _valid = false;
+        };
+
+        if (
+            _valid
+            && {
+                _players findIf {
+                    _x distance2D _candidate < _minPlayerDistance
+                } >= 0
+            }
+        ) then {
+            _valid = false;
+        };
+
+        if (
+            _valid
+            && {
+                _reserved findIf {
+                    _x distance2D _candidate < _groupSeparation
+                } >= 0
+            }
+        ) then {
+            _valid = false;
+        };
+
+        if (
+            _valid
+            && {
+                !(
+                    nearestObjects [
+                        _candidate,
+                        ["Man", "LandVehicle", "Air", "Ship", "StaticWeapon", "Building", "House", "ThingX"],
+                        _objectClearance,
+                        true
+                    ]
+                    isEqualTo []
+                )
+            }
+        ) then {
+            _valid = false;
+        };
+
+        if (
+            _valid
+            && {
+                !(
+                    nearestTerrainObjects [
+                        _candidate,
+                        ["BUILDING", "BUNKER", "FENCE", "FORTRESS", "HOUSE", "ROCK", "ROCKS", "TREE", "WALL"],
+                        _terrainClearance,
+                        false,
+                        true
+                    ]
+                    isEqualTo []
+                )
+            }
+        ) then {
+            _valid = false;
+        };
+
+        if (
+            _valid
+            && {
+                !([_candidate, _kind, _sampleRadius, _sampleHeight, _players] call _fnc_hidden)
+            }
+        ) then {
+            _valid = false;
+        };
+
+        if (_valid) exitWith {
+            _accepted = _candidate;
+        };
     };
+
     _accepted
 };
 
 private _fnc_nearestGroundLeader = {
-    params ["_group"];
+    params ["_group", "_players"];
+
     private _source = leader _group;
     if (isNull _source) exitWith { objNull };
 
-    private _players = ([] call CBA_fnc_players) select {
-        alive _x
-        && {side group _x isEqualTo _targetSide}
-        && {!((vehicle _x) isKindOf "Air")}
+    private _groundPlayers = _players select {
+        side group _x isEqualTo _targetSide
+        && { !((vehicle _x) isKindOf "Air") }
     };
-    if (_players isEqualTo []) exitWith { objNull };
 
-    private _leaders = _players select { leader group _x isEqualTo _x };
-    private _pool = if (_leaders isEqualTo []) then { _players } else { _leaders };
+    if (_groundPlayers isEqualTo []) exitWith { objNull };
+
+    private _leaders = _groundPlayers select {
+        leader group _x isEqualTo _x
+    };
+    private _pool = if (_leaders isEqualTo []) then {
+        _groundPlayers
+    } else {
+        _leaders
+    };
+
     private _nearest = _pool select 0;
     private _bestDistance = _source distance2D _nearest;
 
@@ -178,59 +336,37 @@ private _fnc_nearestGroundLeader = {
             _bestDistance = _distance;
         };
     } forEach _pool;
+
     _nearest
 };
 
-private _fnc_ignoreAircraft = {
-    params ["_group"];
-    if !(_config get "ignoreAircraft") exitWith {};
-    {
-        _group ignoreTarget _x;
-    } forEach (vehicles select { alive _x && {_x isKindOf "Air"} });
-};
-
-private _fnc_prepareInfantry = {
-    params ["_group"];
-    _group setBehaviourStrong "AWARE";
-    _group setCombatMode "YELLOW";
-    _group setSpeedMode "FULL";
-    _group enableAttack false;
-    _group allowFleeing 0;
+private _fnc_taskInfantry = {
+    params ["_group", "_players"];
 
     if (_config get "lambsReinforcement") then {
-        _group setVariable ["lambs_danger_enableGroupReinforce",true,true];
+        _group setVariable ["lambs_danger_enableGroupReinforce", true, true];
     };
 
     {
         _x enableStamina false;
         _x enableFatigue false;
-        _x forceSpeed -1;
-        _x setUnitPos "AUTO";
-        _x enableAI "MOVE";
-        _x enableAI "PATH";
-        _x enableAI "FSM";
-        _x enableAI "AUTOCOMBAT";
-        _x enableAI "TARGET";
-        _x enableAI "AUTOTARGET";
-        _x enableAI "SUPPRESSION";
-        _x setVariable ["lambs_danger_dangerRadio",true,true];
+        _x setVariable ["lambs_danger_dangerRadio", true, true];
     } forEach units _group;
 
-    [_group] call _fnc_ignoreAircraft;
-};
+    private _target = [_group, _players] call _fnc_nearestGroundLeader;
+    private _targetPos = if (isNull _target) then {
+        +_centerPos
+    } else {
+        getPosATL _target
+    };
 
-private _fnc_taskInfantry = {
-    params ["_group"];
-    [_group] call _fnc_prepareInfantry;
-
-    private _target = [_group] call _fnc_nearestGroundLeader;
-    private _targetPos = if (isNull _target) then { +_centerPos } else { getPosATL _target };
     _targetPos resize 3;
-    _targetPos set [2,0];
+    _targetPos set [2, 0];
 
     [_group] call CBA_fnc_clearWaypoints;
-    private _waypoint = _group addWaypoint [_targetPos,-1];
-    _waypoint setWaypointType "lambs_danger_CQB";
+
+    private _waypoint = _group addWaypoint [_targetPos, -1];
+    _waypoint setWaypointType (["SAD", "lambs_danger_CQB"] select _hasLAMBS_CQB);
     _waypoint setWaypointBehaviour "AWARE";
     _waypoint setWaypointCombatMode "YELLOW";
     _waypoint setWaypointSpeed "FULL";
@@ -238,123 +374,172 @@ private _fnc_taskInfantry = {
     _group setCurrentWaypoint _waypoint;
     _group move _targetPos;
 
-    _group setVariable ["TMC_attackWaypoint",_waypoint];
-    _group setVariable ["TMC_attackTarget",_target];
-    _group setVariable ["TMC_attackTargetPosition",_targetPos];
-    _group setVariable ["TMC_lastLeaderPosition",getPosATL leader _group];
-    _group setVariable ["TMC_lastProgressTime",diag_tickTime];
-    _group setVariable ["TMC_lastRetaskTime",diag_tickTime];
+    private _leader = leader _group;
+    private _now = diag_tickTime;
 
-    if (random 1 < (_config get "lambsKnowledgeSeedChance") && {!isNull _target}) then {
-        (leader _group) reveal [_target,1.25];
+    _group setVariable ["TMC_attackWaypoint", _waypoint];
+    _group setVariable ["TMC_attackTarget", _target];
+    _group setVariable ["TMC_attackTargetPosition", _targetPos];
+    _group setVariable ["TMC_lastLeaderPosition", getPosATL _leader];
+    _group setVariable ["TMC_lastProgressTime", _now];
+    _group setVariable ["TMC_lastTargetDistance", _leader distance2D _targetPos];
+
+    if (
+        random 1 < (_config get "lambsKnowledgeSeedChance")
+        && { !isNull _target }
+    ) then {
+        _leader reveal [_target, 1.25];
     };
 };
 
 private _fnc_taskVehicle = {
     params ["_group"];
+
     _group setBehaviourStrong "AWARE";
     _group setCombatMode "RED";
     _group setSpeedMode "FULL";
-    private _wp = _group addWaypoint [_centerPos,_config get "searchRadius"];
-    _wp setWaypointType "SAD";
-    _wp setWaypointBehaviour "COMBAT";
-    _wp setWaypointCombatMode "RED";
-    _wp setWaypointSpeed "FULL";
+
+    private _waypoint = _group addWaypoint [
+        _centerPos,
+        _config get "searchRadius"
+    ];
+    _waypoint setWaypointType "SAD";
+    _waypoint setWaypointBehaviour "COMBAT";
+    _waypoint setWaypointCombatMode "RED";
+    _waypoint setWaypointSpeed "FULL";
 };
 
 private _fnc_spawnInfantry = {
-    params ["_template","_position"];
-    private _classes = +(_template getOrDefault ["units",[]]);
+    params ["_template", "_position", "_players"];
+
+    private _classes = +(_template getOrDefault ["units", []]);
     if (_classes isEqualTo []) exitWith { grpNull };
 
-    private _group = [_position,_side,_classes,[],[],[],[],[],_position getDir _centerPos,true] call BIS_fnc_spawnGroup;
+    private _group = [
+        _position,
+        _side,
+        _classes,
+        [],
+        [],
+        [],
+        [],
+        [],
+        _position getDir _centerPos,
+        true
+    ] call BIS_fnc_spawnGroup;
+
     if (isNull _group) exitWith { grpNull };
 
     _group deleteGroupWhenEmpty true;
-    _group setFormation (_template getOrDefault ["formation","STAG COLUMN"]);
-    private _skill = _template getOrDefault ["skill",[0.4,0.55]];
+
+    private _skill = _template getOrDefault ["skill", [0.4, 0.55]];
     {
-        private _value = if (_skill isEqualType []) then { (_skill select 0) + random ((_skill select 1)-(_skill select 0)) } else { _skill };
+        private _value = if (_skill isEqualType []) then {
+            (_skill select 0) + random ((_skill select 1) - (_skill select 0))
+        } else {
+            _skill
+        };
         _x setSkill ((_value max 0) min 1);
     } forEach units _group;
 
-    [_group] call _fnc_taskInfantry;
+    [_group, _players] call _fnc_taskInfantry;
     _group
 };
 
 private _fnc_spawnVehicle = {
-    params ["_template","_position"];
-    private _class = _template getOrDefault ["vehicleClass",""];
-    if (_class isEqualTo "") exitWith { [objNull,grpNull] };
+    params ["_template", "_position"];
 
-    private _vehicle = createVehicle [_class,_position,[],0,"NONE"];
-    if (isNull _vehicle) exitWith { [objNull,grpNull] };
+    private _class = _template getOrDefault ["vehicleClass", ""];
+    if (_class isEqualTo "") exitWith { [objNull, grpNull] };
+
+    private _vehicle = createVehicle [_class, _position, [], 0, "NONE"];
+    if (isNull _vehicle) exitWith { [objNull, grpNull] };
 
     _vehicle setDir (_position getDir _centerPos);
     createVehicleCrew _vehicle;
+
     private _group = group effectiveCommander _vehicle;
 
     if (isNull _group) then {
         deleteVehicle _vehicle;
-        [objNull,grpNull]
+        [objNull, grpNull]
     } else {
         _group deleteGroupWhenEmpty true;
         [_group] call _fnc_taskVehicle;
-        [_vehicle,_group]
+        [_vehicle, _group]
     }
 };
 
-for "_index" from 1 to round (_config get "infantryGroupCount") do {
+private _infantryOperations = round ((_config get "infantryGroupCount") max 0);
+private _vehicleOperations = round ((_config get "vehicleGroupCount") max 0);
+private _remainingOperations = _infantryOperations + _vehicleOperations;
+
+for "_index" from 1 to _infantryOperations do {
     private _template = [_config get "infantryTemplates"] call _fnc_pickWeighted;
+
     if ((count _template) isEqualTo 0) then {
-        _failed pushBack ["INFANTRY",_index,"NO_TEMPLATE"];
+        _failed pushBack ["INFANTRY", _index, "NO_TEMPLATE"];
     } else {
-        private _position = ["INFANTRY",_template] call _fnc_findPosition;
+        private _position = ["INFANTRY", _template, _livingPlayers] call _fnc_findPosition;
+
         if (_position isEqualTo []) then {
-            _failed pushBack ["INFANTRY",_index,"NO_POSITION"];
+            _failed pushBack ["INFANTRY", _index, "NO_POSITION"];
         } else {
-            private _group = [_template,_position] call _fnc_spawnInfantry;
+            private _group = [_template, _position, _livingPlayers] call _fnc_spawnInfantry;
+
             if (isNull _group) then {
-                _failed pushBack ["INFANTRY",_index,"SPAWN_FAILED"];
+                _failed pushBack ["INFANTRY", _index, "SPAWN_FAILED"];
             } else {
                 _reserved pushBack _position;
                 _spawnedGroups pushBack _group;
-                [_group,"INFANTRY",_template,_position,objNull,_config] call (_config get "onGroupSpawned");
+                [_group, "INFANTRY", _template, _position, objNull, _config] call (_config get "onGroupSpawned");
             };
         };
     };
-    if (_spawnDelay > 0) then { sleep _spawnDelay };
+
+    _remainingOperations = _remainingOperations - 1;
+    if (_spawnDelay > 0 && { _remainingOperations > 0 }) then {
+        sleep _spawnDelay;
+    };
 };
 
-for "_index" from 1 to round (_config get "vehicleGroupCount") do {
+for "_index" from 1 to _vehicleOperations do {
     private _template = [_config get "vehicleTemplates"] call _fnc_pickWeighted;
+
     if ((count _template) isEqualTo 0) then {
-        _failed pushBack ["VEHICLE",_index,"NO_TEMPLATE"];
+        _failed pushBack ["VEHICLE", _index, "NO_TEMPLATE"];
     } else {
-        private _position = ["VEHICLE",_template] call _fnc_findPosition;
+        private _position = ["VEHICLE", _template, _livingPlayers] call _fnc_findPosition;
+
         if (_position isEqualTo []) then {
-            _failed pushBack ["VEHICLE",_index,"NO_POSITION"];
+            _failed pushBack ["VEHICLE", _index, "NO_POSITION"];
         } else {
-            private _spawn = [_template,_position] call _fnc_spawnVehicle;
-            _spawn params ["_vehicle","_group"];
-            if (isNull _vehicle || {isNull _group}) then {
-                _failed pushBack ["VEHICLE",_index,"SPAWN_FAILED"];
+            private _spawn = [_template, _position] call _fnc_spawnVehicle;
+            _spawn params ["_vehicle", "_group"];
+
+            if (isNull _vehicle || { isNull _group }) then {
+                _failed pushBack ["VEHICLE", _index, "SPAWN_FAILED"];
             } else {
                 _reserved pushBack _position;
                 _spawnedVehicles pushBack _vehicle;
                 _spawnedGroups pushBack _group;
-                [_group,"VEHICLE",_template,_position,_vehicle,_config] call (_config get "onGroupSpawned");
+                [_group, "VEHICLE", _template, _position, _vehicle, _config] call (_config get "onGroupSpawned");
             };
         };
     };
-    if (_spawnDelay > 0) then { sleep _spawnDelay };
+
+    _remainingOperations = _remainingOperations - 1;
+    if (_spawnDelay > 0 && { _remainingOperations > 0 }) then {
+        sleep _spawnDelay;
+    };
 };
 
 private _result = createHashMapFromArray [
-    ["success",true],
-    ["groups",_spawnedGroups],
-    ["vehicles",_spawnedVehicles],
-    ["failedSpawns",_failed]
+    ["success", _failed isEqualTo []],
+    ["groups", _spawnedGroups],
+    ["vehicles", _spawnedVehicles],
+    ["failedSpawns", _failed]
 ];
-[_result,_config] call (_config get "onComplete");
+
+[_result, _config] call (_config get "onComplete");
 _result


### PR DESCRIPTION
Adds the complete v5 Clone Wars continuous reinforcement package.

Current implementation includes:
- 3:1 infantry scaling and 1:10 vehicle scaling
- reinforcement decisions based on the actual number of living managed OPFOR infantry
- staggered infantry, vehicle, scaling, and behavior evaluations
- managed group and vehicle registries instead of repeated allGroups/vehicles scans
- due-only scheduler work with production logging disabled by default
- cached living-player lists during spawn searches
- cached Clone Wars templates and one-time class validation
- direct wrapper-to-spawner calls without nested scheduled scripts
- 40 spawn-position attempts and visibility checks limited to 1500 meters
- weighted 30-unit B1 assault, 20-unit B1 fire-support, and 10-unit mixed B1/B2 formations
- separate six-unit BX Commando teams
- separate three-unit B2 Hunter Cells
- independent one-unit Droidekas
- depleted regular infantry groups merge when they fall below five living units
- merging is limited to compatible regular groups within 300 meters and a maximum destination size of 30
- source and destination groups do not merge while actively clearing buildings, rushing enemies, or fighting enemies within 125 meters
- LAMBS Task CQB targeting the nearest living ground-based BLUFOR leader
- dynamic waypoint updates and a combat-aware stuck-group watchdog
- aircraft filtering through an EntityCreated event handler and aircraft registry
- 25 percent LAMBS knowledge seeding
- shared group-cap accounting that prevents simultaneous over-allocation
- manual PAUSE and RESUME controls; low FPS blocks new packages but does not enter the paused state

The code has been statically reviewed, but still requires an in-game dedicated-server test with the mission modpack.